### PR TITLE
Extended roadmap section

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -817,12 +817,11 @@ The curve E forms an algebraic group, whose elements are the
 points (x, y) satisfying the curve equation, where x and y are elements of F.
 This group has order n, meaning that there are n distinct points.
 
-For security reasons, groups of prime order MUST be used since they lead to the
-more difficult instances of the discrete logarithm problem. Elliptic curves
+For security reasons, groups of prime order MUST be used. Elliptic curves
 induce subgroups of prime order. Let G be a subgroup of the curve of prime
 order r, where n = h * r.
 In this equation, h is an integer called the cofactor.
-The process of mapping to an elliptic curve point to a point in G is
+The process of mapping an elliptic curve point to a point in G is
 called clearing the cofactor, this operation is described in {{cofactor-clearing}}.
 
 Certain encoding functions restrict the form of the curve equation, the
@@ -923,15 +922,12 @@ presented. The construction of these mappings relies on three basic functions.
     subgroup G of the curve. {{cofactor-clearing}} describes methods to perform
     this operation.
 
-Each function holds particular properties that are described in the subsequent
-sections.
-
 Two top-level functions taking as input a bit string and returning points on
 the curve are introduced. Although these functions have the same interface, the
 distribution of the points they produce are different. The first function is
 called injective encoding and its probability distribution of the points can be
-easily distinguished from a uniform distribution of points on the curve. On the
-other hand, the second function behaves as a hash function since its output is
+easily distinguished from a uniform distribution of points on the curve. The
+second function behaves as a hash function since its output is
 indistinguishable from a uniform distribution of the points on the curve.
 
 -   Injective encodings. A bit string is mapped to a point in G, however,

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1931,11 +1931,11 @@ that underly the recommendations in this document.
 This section is provided for informational purposes only.
 
 A naive but generally insecure method of mapping a string alpha to
-a point on an elliptic curve E having n points is to first fix a point G that
+a point on an elliptic curve E having n points is to first fix a point P that
 generates the elliptic curve group, and a hash function Hn from bitstrings
-to integers less than n; then compute Hn(alpha) * G, where the * operator
+to integers less than n; then compute Hn(alpha) * P, where the * operator
 represents scalar multiplication. The reason this approach is insecure is
-that the resulting point has a known discrete log relationship to G.
+that the resulting point has a known discrete log relationship to P.
 Thus, except in cases where this method is specified by the protocol,
 it must not be used; doing so risks catastrophic security failures.
 
@@ -1987,7 +1987,7 @@ Brier et al. {{BCIMRT10}} give two solutions to this problem.
 The first, which applies only to Icart's method (above), computes F(H0(msg))
 + F(H1(msg)) for two distinct hash functions H0, H1.
 The second, which applies to essentially all deterministic encodings but
-is more costly, computes F(H0(msg)) + H1(msg) * G, for G a generator of the
+is more costly, computes F(H0(msg)) + H1(msg) * P, for P a generator of the
 elliptic curve group.
 Farashahi et al. {{FFSTV13}} improve the analysis of the first method,
 showing that this method applies to essentially all deterministic encodings.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -137,11 +137,11 @@ normative:
       -
         ins: J. Couveignes
         name: Jean-Marc Couveignes
-        org: Université Bordeaux
+        org: Universite Bordeaux
       -
         ins: J. Kammerer
         name: Jean-Gabriel Kammerer
-        org: Université de Rennes
+        org: Universite de Rennes
   F11:
     title: Hashing into Hessian curves
     seriesinfo:
@@ -813,21 +813,22 @@ An elliptic curve E is specified by a cubic equation in two variables and a
 finite field F. An elliptic curve equation takes one of several standard forms,
 including (but not limited to) Weierstrass, Montgomery, and Edwards.
 
-The curve E forms an algebraic group whose elements are the points (x, y)
-satisfying the curve equation, where x and y are elements of F. This group
-has order n, meaning that there are n distinct points (x, y). In general,
-security of cryptographic primitives requires using a group of prime order.
-However, not all elliptic curves induce groups of prime order: most elliptic
-curves have order n = h * r, where r is a large prime and h is an
-integer called the cofactor. Thus, for cryptographic applications a hash
-function to the curve E should return points in the subgroup of order r. For
-a point not in the prime-order subgroup, the process of mapping to a point
-in the prime-order subgroup is called clearing the cofactor; we discuss this
-process in {{cofactor-clearing}}.
+The curve E forms an algebraic group, denoted as E(F), whose elements are the
+points (x, y) satisfying the curve equation, where x and y are elements of F.
+This group has order n, meaning that there are n distinct points.
 
-Certain encoding functions restrict the form of the curve equation, the characteristic
-of the field, and/or the parameters of the curve. For each encoding,
-this document lists the relevant restrictions.
+In general, security of cryptographic primitives requires a group G of
+prime order. However, not all elliptic curves induce groups of prime order.
+Because of that, G is usually taken as a subgroup of E(F) in such a way that G
+has prime order r, where n = h * r. In this equation, h is an integer known as
+the cofactor.
+The process of mapping to an elliptic curve point to a point belonging to a
+subgroup of order r is called clearing the cofactor. We discuss this process
+in {{cofactor-clearing}}.
+
+Certain encoding functions restrict the form of the curve equation, the
+characteristic of the field, and/or the parameters of the curve. For each
+encoding, this document lists the relevant restrictions.
 
 Summary of quantities:
 
@@ -835,9 +836,11 @@ Summary of quantities:
 |:------:|---------|-----------|
 | F,q,p | Finite field F of characteristic p and #F=q=p^m. | For prime fields, q=p; otherwise, q=p^m and m>1. |
 | E | Elliptic curve. | E is specified by an equation and a field F. |
-| n | Number of points on E, #E(F)=n. | This value can be factored as n=h * r. |
-| r | Order of a prime subgroup of E. | If n is not prime, may need mapping to points in a subgroup of order r. |
-| h | Cofactor, h>=1. | Constant used in cofactor clearing to map to prime-order subgroup. |
+| E(F) | The group of points induced by E. | A set of points with coordinates (x,y) satisfying the elliptic curve equation. |
+| n | Number of points on E(F), #E(F)=n. | This value could be prime or composite. |
+| G | A group of r points. | A subgroup of E(F). |
+| r | Order of G. | This value is a prime number. |
+| h | Cofactor, h>=1. | This is an integer number satisfying n = h * r.  |
 
 ## Terminology
 In the following, we categorize the terminology for encoding bitstrings to points
@@ -899,6 +902,41 @@ On the other hand, the uniformity property is not met as the output of an
 encoding is distinguishable from a random distribution. Hence, using
 hash2curve(alpha) is not sufficient to get uniformity, however it can be used
 as a building block for obtaining a random oracle as is described in {{rom}}.
+
+
+# Roadmap on Hash to Curve.
+
+The hash2curve(alpha) mapping defines a general framework for mapping bit
+strings into points of a prime group G.
+
+~~~
+hash2curve(alpha)
+
+Input: alpha, an arbitrary-length bit string.
+Output: P, a point in the group G.
+
+Steps:
+1. u = hash2base(alpha)   // {0,1}* -> F   
+2. Q = map2curve(u)       //    F   -> E(F)
+3. P = clearCofactor(Q)   //   E(F) -> G   
+4. Output P
+~~~
+
+Since the functions in each step must hold particular properties, detailed
+definitions are given in the subsequent sections. Firstly, {{utility}} introduces
+some utility functions that are used across the document. Then, {{hashtobase}}
+describes the hash2base function. Note that there exist several ways to
+instantiate a map2curve function. Thus, some possible choices are described in
+{{encodings}}. Similarly, clearing the cofactor is particular to the group G,
+this is discussed in {{cofactor-clearing}}.
+
+Notice that cryptographic protocols proven in the random oracle model usually
+require that hash2curve mappings behave as random oracles. {{rom}} gives a
+construction of hash2curve that fulfills this requirement.
+
+{{suites}} of this document provides a list of suites for hashing to curve.
+Each suite can be considered as a full set of parameters and algorithms required
+to instantiate a specific hash2curve mapping for a given group G of interest.
 
 # Utility Functions {#utility}
 
@@ -1161,32 +1199,6 @@ As a rough style guide the following convention is used:
 
 - c1, c2, ...: are constant values, which can be computed in advance.
 
-## Clearing the cofactor {#cofactor-clearing}
-
-The encodings of this section always output a point on the elliptic curve,
-i.e., a point in a group of order h * r ({{bg-curves}}).
-Obtaining a point in the subgroup of prime order r may require
-a final operation, called "clearing the cofactor."
-In the description of each encoding in this section, this operation is represented
-abstractly as clear\_h(x, y), which takes as input a point on the curve and returns
-a point in the subgroup of prime order.
-
-The operation clear\_h(x, y) can always be implemented as a scalar multiplication by h.
-For elliptic curves where h = 1, i.e., curves with a prime number of points (for example,
-the NIST curves P-256, P-384, and P-521 {{FIPS186-4}}), no operation is required.
-
-In some cases, it is possible to clear the cofactor via a faster method than scalar multiplication.
-For pairing-friendly curves having subgroup G2 over an extension
-field, Scott et al. {{SBCDBK09}} describe a method for faster cofactor clearing
-that exploits an efficiently-computable endomorphism. Fuentes-Castaneda
-et al. {{FKR11}} propose an alternative method that is sometimes more efficient.
-Budroni and Pintore {{BP18}} give concrete instantiations of these methods
-for Barreto-Lynn-Scott pairing-friendly curves {{BLS02}}.
-
-Wahby and Boneh ({{WB19}}, Section 5) describe a trick due to Scott for
-faster cofactor clearing on any elliptic curve for which the prime
-factorization of h and the number of points on the curve meet certain
-conditions.
 
 ## Sign of the resulting point {#point-sign}
 
@@ -1793,6 +1805,34 @@ Operations:
 We do not repeat the sample implementation of {{simple-swu}} here.
 See {{github-repo}} or {{WB19}} for details on implementing the isogeny map.
 
+# Clearing the cofactor {#cofactor-clearing}
+
+The encodings of this section always output a point on the elliptic curve,
+i.e., a point in a group of order h * r ({{bg-curves}}).
+Obtaining a point in the subgroup of prime order r may require
+a final operation, called "clearing the cofactor."
+In the description of each encoding in this section, this operation is represented
+abstractly as clear\_h(x, y), which takes as input a point on the curve and returns
+a point in the subgroup of prime order.
+
+The operation clear\_h(x, y) can always be implemented as a scalar multiplication by h.
+For elliptic curves where h = 1, i.e., curves with a prime number of points (for example,
+the NIST curves P-256, P-384, and P-521 {{FIPS186-4}}), no operation is required.
+
+In some cases, it is possible to clear the cofactor via a faster method than scalar multiplication.
+For pairing-friendly curves having subgroup G2 over an extension
+field, Scott et al. {{SBCDBK09}} describe a method for faster cofactor clearing
+that exploits an efficiently-computable endomorphism. Fuentes-Castaneda
+et al. {{FKR11}} propose an alternative method that is sometimes more efficient.
+Budroni and Pintore {{BP18}} give concrete instantiations of these methods
+for Barreto-Lynn-Scott pairing-friendly curves {{BLS02}}.
+
+Wahby and Boneh ({{WB19}}, Section 5) describe a trick due to Scott for
+faster cofactor clearing on any elliptic curve for which the prime
+factorization of h and the number of points on the curve meet certain
+conditions.
+
+
 # Random Oracles {#rom}
 
 Brier et al. {{BCIMRT10}} describe two generic constructions that give a
@@ -1800,26 +1840,27 @@ hash function approximating a random oracle. Farashahi et al. {{FFSTV13}}
 and Tibouchi and Kim {{TK17}} refine this analysis. In particular, Farashahi
 et al. show that summing two independent evaluations of any of the
 deterministic endings of {{encodings}} suffices to approximate a random
-oracle to an elliptic curve.
+oracle to an elliptic curve. In other words:
+
+~~~
+   hash2curve(alpha) = f(H0(alpha)) + f(H1(alpha))
+~~~
+
+where f: F -> E is a deterministic encoding, and H0 and H1 are hash
+functions (modeled as random oracles) mapping strings to elements of F.
 
 ## Implementation
 
-To instantiate a random oracle from any of the encodings of {{encodings}},
+To instantiate a random oracle from the encodings of {{encodings}},
 compute the following:
 
 ~~~
-u0 = hash2base(alpha, 0)
-u1 = hash2base(alpha, 1)
-(x, y) = map2curve(u0) + map2curve(u1)
+ hash2curve(alpha) = map2curve( alpha || I2OSP(0, 1) )
+                   + map2curve( alpha || I2OSP(1, 1) )
 ~~~
 
-where map2curve is the chosen encoding and the addition operation is elliptic
-curve point addition.
-
-As described in {{hash2base-perf}}, implementors MAY factor the common
-computation of H(alpha) out of the invocations of hash2base. For long
-messages, this gives good performance without requiring higher-level
-protocols to pre-hash alpha.
+where the addition operations corresponds to point addition on the target
+elliptic curve.
 
 # Suites for Hashing {#suites}
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -813,7 +813,7 @@ An elliptic curve E is specified by a cubic equation in two variables and a
 finite field F. An elliptic curve equation takes one of several standard forms,
 including (but not limited to) Weierstrass, Montgomery, and Edwards.
 
-The curve E forms an algebraic group, whose elements are the
+The curve E forms an algebraic group whose elements are the
 points (x, y) satisfying the curve equation, where x and y are elements of F.
 This group has order n, meaning that there are n distinct points.
 
@@ -822,7 +822,7 @@ induce subgroups of prime order. Let G be a subgroup of the curve of prime
 order r, where n = h * r.
 In this equation, h is an integer called the cofactor.
 The process of mapping an elliptic curve point to a point in G is
-called clearing the cofactor, this operation is described in {{cofactor-clearing}}.
+called clearing the cofactor. This operation is described in {{cofactor-clearing}}.
 
 Certain encoding functions restrict the form of the curve equation, the
 characteristic of the field, and/or the parameters of the curve. For each
@@ -907,10 +907,11 @@ is given in {{roadmap}}.
 
 # Roadmap {#roadmap}
 
-A general framework for mapping bit strings into points of an elliptic curve is
-presented. The construction of these mappings relies on three basic functions.
+This section presents a general framework for mapping bit strings into points
+on an elliptic curve. To construct these mappings, we rely on three basic
+functions:
 
--   The function hash2base, {0, 1}^* -> F, maps arbitrary-length bit strings
+-   The function hash2base, {0, 1}^\* -> F, maps arbitrary-length bit strings
     to elements of a finite field; its implementation is defined in
     {{hashtobase}}.
 
@@ -925,13 +926,13 @@ presented. The construction of these mappings relies on three basic functions.
 Two top-level functions taking as input a bit string and returning points on
 the curve are introduced. Although these functions have the same interface, the
 distribution of the points they produce are different. The first function is
-called injective encoding and its probability distribution of the points can be
-easily distinguished from a uniform distribution of points on the curve. The
-second function behaves as a hash function since its output is
+called an injective encoding and its probability distribution of the points can
+be easily distinguished from a uniform distribution of points on the curve. The
+second function behaves as a random oracle, since its output is
 indistinguishable from a uniform distribution of the points on the curve.
 
--   Injective encodings. A bit string is mapped to a point in G, however,
-    the distribution of its output is not uniform.
+-   Injective encoding. This function maps bit strings to points in G. Note
+    that the distribution of the output is not uniform.
 
     ~~~
     encode2curve(alpha)
@@ -946,10 +947,8 @@ indistinguishable from a uniform distribution of the points on the curve.
     4. return P
     ~~~
 
--   Random Oracle. This function yields a uniform distribution and can be used
-    as a random oracle from strings to points on the curve. Where appropriate,
-    the terms random oracle and hash functions for such mappings are used
-    interchangeably.
+-   Random Oracle. This function maps bit strings to points in G that are
+    indistinguishable from uniformly random.
 
     ~~~
     hash2curve(alpha)
@@ -1871,23 +1870,23 @@ A suite is a bundle of algorithms that provides concrete recommendations for
 hashing bitstrings into points of specific elliptic curve groups. Each suite is
 a tuple (E, H, f, ROM) such that
 
-* E, is the elliptic curve group.
-* H, is the cryptographic hash function used by hash2base.
-* f, is an encoding function compatible with E.
-* ROM, is a boolean flag indicating whether or not to use the random oracle construction.
+-   E, is the elliptic curve group.
+-   H, is the cryptographic hash function used by hash2base.
+-   f, is an encoding function compatible with E.
+-   ROM, is a boolean flag indicating whether or not to use the random oracle construction.
 
 This document describes the following set of ciphersuites
 
 | Suite ID | E | H | f | ROM |
 |----------|---|---|---|-----|
-| H2C-0001 | P256         |  SHA256 | Simplified SWU           | True |
-| H2C-0002 | P384         |  SHA512 | Icart                    | True |
-| H2C-0003 | curve25519   |  SHA512 | Elligator 2              | True |
-| H2C-0004 | curve448     |  SHA512 | Elligator 2              | True |
-| H2C-0005 | edwards25519 |  SHA512 | Elligator 2              | True |
-| H2C-0006 | edwards448   |  SHA512 | Elligator 2              | True |
-| H2C-0007 | SECP256K1    |  SHA512 | Shallue-van de Woestijne | True |
-| H2C-0008 | BLS12381     |  SHA512 | Simplified SWU           | True |
+| H2C-0001 | P256         | SHA256 | Simplified SWU           | True |
+| H2C-0002 | P384         | SHA512 | Icart                    | True |
+| H2C-0003 | curve25519   | SHA512 | Elligator 2              | True |
+| H2C-0004 | curve448     | SHA512 | Elligator 2              | True |
+| H2C-0005 | edwards25519 | SHA512 | Elligator 2              | True |
+| H2C-0006 | edwards448   | SHA512 | Elligator 2              | True |
+| H2C-0007 | SECP256K1    | SHA512 | Shallue-van de Woestijne | True |
+| H2C-0008 | BLS12381     | SHA512 | Simplified SWU           | True |
 
 
 # IANA Considerations
@@ -1913,12 +1912,12 @@ earlier versions of this document.
 
 # Contributors
 
-* Sharon Goldberg \\
-  Boston University \\
-  goldbe@cs.bu.edu
-* Ela Lee \\
-  Royal Holloway, University of London \\
-  Ela.Lee.2010@live.rhul.ac.uk
+*   Sharon Goldberg \\
+    Boston University \\
+    goldbe@cs.bu.edu
+*   Ela Lee \\
+    Royal Holloway, University of London \\
+    Ela.Lee.2010@live.rhul.ac.uk
 
 --- back
 


### PR DESCRIPTION
Changes:
 - Roadmap section is expanded to introduce 2 types of functions
   to be supported. Injective Encodings and Random Oracles. (the
   names can be changed accordingly).
 - The Random oracle section was merged in Section 2.2.3. in which
   only alerts the reader how to construct a random oracle using
   FFSTV.
 - For efficiency, clear cofactor is performed once. #120.

TBD:
 - In the random oracle, hash2base is hashing twice the input, this
   can be fixed by removing the call to the hash function from
   hash2base.
 - As always, names of functions and variables can be changed to
   something meaningful.
