### PR TITLE
update description of Edwards map

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -118,19 +118,6 @@ informative:
         ins: C. Peters
         name: Christiane Peters
         org: Department of Mathematics and Computer Science, Technische Universiteit Eindhoven, The Netherlands
-  M87:
-    title: Speeding the Pollard and clliptic curve methods of factorization
-    seriesinfo:
-        "In": Mathematics of Computation, vol 48
-        "pages": 243-264
-        DOI: 10.1090/S0025-5718-1987-0866113-7
-    target: https://doi.org/10.1090/S0025-5718-1987-0866113-7
-    date: 1987
-    author:
-      -
-        ins: P. L. Montgomery
-        name: Peter L. Montgomery
-        org: System Development Corporation, Santa Monica, CA
   CK11:
     title: The geometry of flex tangents to a cubic curve and its parameterizations
     seriesinfo:
@@ -1643,11 +1630,6 @@ given by
 
 For completeness, we give the inverse map in {{birational-map-inverse}}.
 Note that the inverse map is not used when hashing to a twisted Edwards curve.
-
-Note that the above map can be evaluated with just one inversion using
-Montgomery's trick {{M87}}.
-First, compute t = y' * (B' * x' + 1).
-Then t * y' == 1 / (B' * x' + 1) and t * (B' * x' + 1) == 1 / y'.
 
 Birational maps are undefined when the denominator of either
 rational function is zero.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -53,8 +53,8 @@ author:
 normative:
   RFC2119:
   RFC8017:
-informative:
   RFC7748:
+informative:
   SECG1:
     title: "SEC 1: Elliptic Curve Cryptography"
     target: http://www.secg.org/sec1-v2.pdf
@@ -1259,9 +1259,9 @@ The generic interface shared by all mappings in this section is as follows:
 (x, y) = map_to_curve(u)
 ~~~
 
-The output (x, y) specifies a point on an elliptic curve defined over base field F;
-x and y are elements of F.
-Note that the output (x, y) is not a uniformly random point. If uniformity
+The input u and outputs x and y are elements of the field F.
+The coordinates (x, y) specifiy a point on an elliptic curve defined over F.
+Note that the point (x, y) is not a uniformly random point. If uniformity
 is required for security, the random oracle construction of {{roadmap}} MUST be
 used instead.
 
@@ -1317,7 +1317,7 @@ E: y^2 = g(x) = x^3 + A * x + B, where 4 * A^3 + 27 * B^2 != 0.
 
 ### Icart Method {#icart}
 
-The function map\_to\_curve\_icart(alpha) implements the Icart method from {{Icart09}}.
+The function map\_to\_curve\_icart(u) implements the Icart method from {{Icart09}}.
 
 Preconditions: An elliptic curve over F, such that p>3 and q=p^m=2 (mod 3), or
 p=2 (mod 3) and odd m.
@@ -1380,7 +1380,7 @@ Steps:
 
 ### Simplified Shallue-van de Woestijne-Ulas Method {#simple-swu}
 
-The function map\_to\_curve\_simple\_swu(alpha) implements a simplification
+The function map\_to\_curve\_simple\_swu(u) implements a simplification
 of the Shallue-van de Woestijne-Ulas mapping {{U07}} described by Brier et
 al. {{BCIMRT10}}, which they call the "simplified SWU" map. Wahby and Boneh
 {{WB19}} generalize this mapping to curves over fields of odd characteristic p > 3.
@@ -1463,11 +1463,11 @@ Steps:
 22. return (x, y)
 ~~~
 
-## Mappings for Montgomery curves
+## Mappings for Montgomery curves {#montgomery}
 
 ### Elligator 2 Method {#elligator2}
 
-The function map\_to\_curve\_elligator2(alpha) implements Elligator 2 {{BHKL13}} for
+The function map\_to\_curve\_elligator2(u) implements Elligator 2 {{BHKL13}} for
 curves defined by y^2 = x^3 + A * x^2 + B * x such that A * B * (A^2 - 4 * B) != 0
 and A^2 - 4 * B is non-square in F.
 
@@ -1581,75 +1581,121 @@ Steps:
 26. return (x, y)
 ~~~
 
-## Mappings for twisted Edwards curves
+## Mappings for Edwards curves
 
-### Elligator 2 Method {#ell2edwards}
+Edwards curves are closely related to Montgomery
+curves ({{montgomery}}): every Edwards curve is birationally equivalent
+to a Montgomery curve ({{BBJLP08}}, Theorem 3.2).
+This equivalence yields an efficient way of hashing to an Edwards curve:
+first, hash to the equivalent Montgomery curve, then transform the
+result into a point on the Edwards curve by evaluating a pair of rational
+functions called a birational map.
+Thus, hashing to an Edwards curve requires first identifying a
+corresponding Montgomery curve and birational map.
 
-Twisted Edwards curves and Montgomery curves are closely related: every
-twisted Edwards curve is birationally equivalent to a Montgomery curve
-({{BBJLP08}}, Theorem 3.2). To hash to a twisted Edwards curve, hash
-to the equivalent Montgomery curve and evaluate the rational map to
-obtain a point on the twisted Edwards curve.
+### Birational maps from Montgomery to Edwards curves {#birational-map}
 
-For a twisted Edwards curve given by a * x^2 + y^2 = 1 + d * x^2 * y^2,
-first compute A and B, the parameters of the equivalent Montgomery curve,
-as follows:
+There are two ways to identify the Montgomery curve and birational map
+for use with a given Edwards curve.
+
+When hashing to a standard Edwards curves for which a corresponding
+Montgomery form and birational map are also standardized, the standard
+Montgomery form and birational map MUST be used to ensure compatibility
+with existing software.
+Two examples of this are the edwards25519 and edwards448 curves,
+which correspond to the Montgomery curves curve25519 and curve448, respectively.
+For both of these curves, {{RFC7748}} lists both the Montgomery and Edwards
+forms and gives the corresponding rational maps.
+
+Some Edwards curves do not have a standardized Montgomery form.
+In this case, the following procedure MUST be used to derive a birational map.
+For an Edwards curve given by a * x^2 + y^2 = 1 + d * x^2 * y^2,
+first compute A and B, the parameters of the equivalent Montgomery curve
+y'^2 = x'^3 + A * x'^2 + B * x', as follows:
 
 - A = (a + 2) / 2
 - B = (a - d)^2 / 16
 
-Next, use A and B as the curve parameters in the Elligator 2 method of
-{{elligator2}} to obtain a point (x', y') on the Montgomery curve.
-Finally, convert (x', y') to a point (x, y) on the target curve.
-Letting B' = 4 / (a - d), compute
+Next, let B' = 4 / (a - d). Then the birational map from the point (x', y')
+on the Montgomery curve to the point (x, y) on the Edwards curve is given by
 
 - x = x' / y'
 - y = (B' * x' - 1) / (B' * x' + 1)
 
-This can be done in one inversion using Montgomery's trick {{M87}}:
-invert the product y' * (B' * x' + 1), then multiply by y' to obtain
-1 / (B' * x' + 1), and likewise for 1 / y'.
+Note that this map can be evaluated with just one inversion using
+Montgomery's trick {{M87}}.
+First, compute t = y' * (B' * x' + 1).
+Then t * y' == 1 / (B' * x' + 1) and t * (B' * x' + 1) == 1 / y'.
 
-Preconditions: A twisted Edwards curve.
+Birational maps are undefined when the denominator of either
+rational function is zero.
+For example, in the map described above, the exceptional cases are
+y' == 0 or B' * x' == -1.
+Implementations MUST detect exceptional cases and return the value
+(x, y) = (0, 1), which is a valid point on all Edwards curves
+given by the equation above.
 
-Constants:
+The following straight-line implementation of the above rational map
+handles the exceptional cases.
+Implementations of other rational maps (e.g., the ones give in {{RFC7748}})
+are analogous.
 
-- A and B, the parameters of the equivalent Montgomery curve, and B' = 1 / sqrt(B).
+~~~
+birational_map(x', y')
+Input: (x', y'), a point on a Montgomery curve.
+Output: (x, y), a point on the equivalent Edwards curve.
 
-- Z, the smallest (in absolute value) non-square in F, breaking ties by choosing
-  the positive value.
+1. t1 = y' * B'
+2. t2 = x' + 1
+3. t3 = t1 * t2
+4. t3 = inv0(t3)
+5.  x = t2 * t3
+6.  x = x * x'
+7.  y = x' - 1
+8.  y = y * t3
+9.  y = y * t1
+10. e = y == 0
+11. y = CMOV(y, 1, e)
+12. return (x, y)
+~~~
 
-Sign of y: for this map, the sign is determined by map\_to\_curve_elligator2.
+### Elligator 2 Method {#ell2edwards}
+
+Preconditions: A twisted Edwards curve E and a birationally equivalent
+Montgomery curve M.
+
+Helper functions:
+
+- map\_to\_curve\_elligator2 is the mapping of {{elligator2}} to the curve M.
+- birational\_map is a function that takes a point (x', y') on M and
+  returns a point (x, y) on E, as defined in {{birational-map}}.
+
+Sign of y: for this map, the sign is determined by map\_to\_curve\_elligator2.
 No further sign adjustments are required.
 
 Exceptions: The exceptions for the Elligator 2 mapping are as given in
-{{elligator2}}. When converting to a point on the twisted Edwards curve, the remaining exceptions
-are y' == 0 or B' * x' == -1. Implementors must detect these cases and return (x, y) = (0, 1).
+{{elligator2}}.
+The exceptions for the birational map are as given in {{birational-map}}.
+No other exceptions are possible.
 
-The following straight-line implementation handles the exceptional cases:
+The following procedure implements the Elligator 2 mapping for an Edwards
+curve.
 
 ~~~
-1. (x', y') = map_to_curve_elligator2(u)   // a Montgomery point
-2.       x' = x' * B'
-3.       y' = y' * B'
-4.       t1 = x' + 1
-5.       t2 = y' * t1
-6.       t2 = inv0(t2)
-7.        x = t1 * t2
-8.        x = x * x'
-9.        y = x' - 1
-10.       y = y * t2
-11.       y = y * y'
-12.       e = y == 0
-13.       y = CMOV(y, 1, e)
-14. return (x, y)
+map_to_curve_ell2edwards(u)
+Input: u, an element of F.
+Output: (x, y), a point on E.
+
+1. (x', y') = map_to_curve_elligator2(u)    // (x', y') is on M
+2.   (x, y) = birational_map(x', y')        // (x, y) is on E
+3. return (x, y)
 ~~~
 
 ## Mappings for Supersingular curves
 
 ### Boneh-Franklin Method {#supersingular}
 
-The function map\_to\_curve\_bf(alpha) implements the Boneh-Franklin method {{BF01}} which
+The function map\_to\_curve\_bf(u) implements the Boneh-Franklin method {{BF01}} which
 covers the supersingular curves defined by y^2 = x^3 + B over a field F such
 that q=2 (mod 3).
 
@@ -1692,7 +1738,7 @@ Steps:
 
 ### Elligator 2, A=0 Method
 
-The function map\_to\_curve\_ell2A0(alpha) implements an adaptation of Elligator 2
+The function map\_to\_curve\_ell2A0(u) implements an adaptation of Elligator 2
 {{BLMP19}} targeting curves given by y^2 = x^3 + B * x over F such that q=3 (mod 4).
 
 Preconditions: A supersingular curve over F such that q=3 (mod 4).
@@ -1884,8 +1930,8 @@ Operations:
 
 ~~~
 1. (x', y') = map_to_curve_simple_swu(u)    // (x', y') is on E'
-8. (x, y)   = iso_map(x', y')            // (x, y) is on E
-8. return (x, y)
+2.   (x, y) = iso_map(x', y')               // (x, y) is on E
+3. return (x, y)
 ~~~
 
 We do not repeat the sample implementation of {{simple-swu}} here.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1260,7 +1260,7 @@ The generic interface shared by all mappings in this section is as follows:
 ~~~
 
 The input u and outputs x and y are elements of the field F.
-The coordinates (x, y) specifiy a point on an elliptic curve defined over F.
+The coordinates (x, y) specify a point on an elliptic curve defined over F.
 Note that the point (x, y) is not a uniformly random point. If uniformity
 is required for security, the random oracle construction of {{roadmap}} MUST be
 used instead.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1626,6 +1626,9 @@ on the Montgomery curve to the point (x, y) on the Edwards curve is given by
 - x = x' / y'
 - y = (B' * x' - 1) / (B' * x' + 1)
 
+For completeness, we give the inverse map in {{birational-map-inverse}}.
+Note that the inverse map is not used when hashing to an Edwards curve.
+
 Note that this map can be evaluated with just one inversion using
 Montgomery's trick {{M87}}.
 First, compute t = y' * (B' * x' + 1).
@@ -2113,6 +2116,33 @@ curve points to uniformly random bit strings, giving solutions for a class of
 curves including Montgomery and Edwards curves.
 Tibouchi {{T14}} and Aranha et al. {{AFQTZ14}} generalize these results.
 This document does not deal with this complementary problem.
+
+# Birational maps from Edwards to Montgomery curves {#birational-map-inverse}
+
+The inverse of the birational map specified in {{birational-map}}, i.e.,
+the map from the point (x', y') on the Montgomery curve
+y'^2 = x'^3 + A * x'^2 + B * x'
+to the point (x, y) on the Edwards curve
+a * x^2 + y^2 = 1 + d * x^2 * y^2
+is given by:
+
+- x' = (1 + y) / (B' * (1 - y))
+- y' = (1 + y) / (B' * x * (1 - y))
+
+where B' = 4 / (a - d).
+
+This map is undefined when y == 1 or x == 0.
+In this case, return the point (0, 0).
+
+It is sometimes convenient to instead deal with a Montgomery curve
+of the form B' * y''^2 = x''^3 + A' * x''^2 + x''.
+This curve is equivalent to the Montgomery curve above via the
+following change of variables:
+
+- A' = 2 * (a + d) / (a - d)
+- B' = 4 / (a - d)
+- x'' = x' * B'
+- y'' = y' * B'
 
 # Sample Code {#samplecode}
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1581,9 +1581,11 @@ Steps:
 26. return (x, y)
 ~~~
 
-## Mappings for Edwards curves
+## Mappings for Twisted Edwards curves
 
-Edwards curves are closely related to Montgomery
+Twisted and untwisted Edwards curves
+(which this document refers to generically as Edwards curves)
+are closely related to Montgomery
 curves ({{montgomery}}): every Edwards curve is birationally equivalent
 to a Montgomery curve ({{BBJLP08}}, Theorem 3.2).
 This equivalence yields an efficient way of hashing to an Edwards curve:
@@ -1594,12 +1596,12 @@ This method of hashing to an Edwards curve requires first identifying a
 corresponding Montgomery curve and birational map.
 We describe how to identify this curve and map immediately below.
 
-### Birational maps from Montgomery to Edwards curves {#birational-map}
+### Birational maps from Montgomery to Twisted Edwards curves {#birational-map}
 
 There are two ways to identify the correct Montgomery curve and
 birational map for use when hashing to a given Edwards curve.
 
-When hashing to a standard Edwards curve for which a corresponding
+When hashing to a standardized Edwards curve for which a corresponding
 Montgomery form and birational map are also standardized, the standard
 Montgomery form and birational map MUST be used to ensure compatibility
 with existing software.
@@ -2130,7 +2132,7 @@ curves including Montgomery and Edwards curves.
 Tibouchi {{T14}} and Aranha et al. {{AFQTZ14}} generalize these results.
 This document does not deal with this complementary problem.
 
-# Birational maps from Edwards to Montgomery curves {#birational-map-inverse}
+# Birational maps from Twisted Edwards to Montgomery curves {#birational-map-inverse}
 
 The inverse of the birational map specified in {{birational-map}}, i.e.,
 the map from the point (x', y') on the Montgomery curve

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1602,12 +1602,13 @@ When hashing to a standard Edwards curves for which a corresponding
 Montgomery form and birational map are also standardized, the standard
 Montgomery form and birational map MUST be used to ensure compatibility
 with existing software.
-Two examples of this are the edwards25519 and edwards448 curves,
+Two examples of standardized curves are the edwards25519 and edwards448 curves,
 which correspond to the Montgomery curves curve25519 and curve448, respectively.
 For both of these curves, {{RFC7748}} lists both the Montgomery and Edwards
-forms and gives the corresponding rational maps.
+forms and gives the corresponding rational maps
+(for curve25519/edwards25519, Section 4.1; for curve448/edwards448, Section 4.2).
 
-Some Edwards curves do not have a standardized Montgomery form.
+Some Edwards curves lack a standardized Montgomery form or birational map.
 In this case, the following procedure MUST be used to derive a birational map.
 For an Edwards curve given by a * x^2 + y^2 = 1 + d * x^2 * y^2,
 first compute A and B, the parameters of the equivalent Montgomery curve
@@ -1682,7 +1683,7 @@ The following procedure implements the Elligator 2 mapping for an Edwards
 curve.
 
 ~~~
-map_to_curve_ell2edwards(u)
+map_to_curve_elligator2_edwards(u)
 Input: u, an element of F.
 Output: (x, y), a point on E.
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1472,8 +1472,8 @@ Montgomery curve by computing
 - x' = B' * x
 - y' = B' * y
 
-Note that when B = 1, the above two curve equations are identical,
-and no conversion is necessary.
+Note that when B and B' are equal to 1, the above two curve equations
+are identical and no conversion is necessary.
 This is the case, for example, for Curve25519 and Curve448 {{RFC7748}}.
 
 ### Elligator 2 Method {#elligator2}
@@ -1687,8 +1687,8 @@ Output: (x, y), a point on the equivalent twisted Edwards curve.
 
 ### Elligator 2 Method {#ell2edwards}
 
-Preconditions: A twisted Edwards curve E and an equivalent curve M, either
-in Montgomery form ({{montgomery}}) or in the Weierstrass form given in {{rational-map}}.
+Preconditions: A twisted Edwards curve E and an equivalent curve M
+meeting the requirements in {{rational-map}}.
 
 Helper functions:
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1291,10 +1291,10 @@ In general, elliptic curves have equations of the form y^2 = g(x).
 Most of the mappings in this section first identify an x such that
 g(x) is square, then take a square root to find y. Since there
 are two square roots when g(x) != 0, this results in an ambiguity
-regarding the sign of the resulting point.
+regarding the sign of y.
 
 To resolve this ambiguity, the mappings in this section specify
-the sign of the resulting point in terms of the input to the mapping function.
+the sign of the y-coordinate in terms of the input to the mapping function.
 Two main reasons support this approach. First, this covers elliptic curves over
 any field in a uniform way, and second, it gives implementors leeway to optimize
 their square-root implementations.
@@ -1324,8 +1324,8 @@ p=2 (mod 3) and odd m.
 
 Constants: A and B, the parameters of the Weierstrass curve.
 
-Sign of the result: this mapping does not compute a square root, so there
-is no ambiguity regarding sign.
+Sign of y: this mapping does not compute a square root, so there
+is no ambiguity regarding the sign of y.
 
 Exceptions: The only exceptional case is u == 0.
 Implementations must detect this case by testing whether u == 0
@@ -1394,7 +1394,7 @@ Constants:
 - Z, the smallest (in absolute value) non-square in F such that g(B / (Z *
   A)) is square in F, breaking ties by choosing the positive value.
 
-Sign of the result: Inputs u and -u give the same x-coordinate.
+Sign of y: Inputs u and -u give the same x-coordinate.
 Thus, we set sgn0(y) == sgn0(u).
 
 Exceptions: The exceptional cases are values of u such that
@@ -1480,7 +1480,7 @@ Constants:
 - Z, the smallest (in absolute value) non-square in F, breaking ties by choosing
   the positive value.
 
-Sign of the result: Inputs u and -u give the same x-coordinate.
+Sign of y: Inputs u and -u give the same x-coordinate.
 Thus, we set sgn0(y) == sgn0(u).
 
 Exceptions: The exceptional case is Z * u^2 == -1, i.e., 1 + Z * u^2 == 0.
@@ -1677,10 +1677,8 @@ Helper functions:
 - birational\_map is a function that takes a point (x', y') on M and
   returns a point (x, y) on E, as defined in {{birational-map}}.
 
-Sign of the result: existing standards may be ambiguous as to the sign
-of the birational map from M to E.
-To ensure consistency across implementations, we fix the sign of the
-result by setting sgn0(x) == sgn0(u) after applying the birational map.
+Sign of y: for this map, the sign is determined by map\_to\_curve\_elligator2.
+No further sign adjustments are required.
 
 Exceptions: The exceptions for the Elligator 2 mapping are as given in
 {{elligator2}}.
@@ -1697,8 +1695,7 @@ Output: (x, y), a point on E.
 
 1. (x', y') = map_to_curve_elligator2(u)    // (x', y') is on M
 2.   (x, y) = birational_map(x', y')        // (x, y) is on E
-3. If sgn0(u) != sgn0(x), set x = -x        // fix the sign of the result
-4. return (x, y)
+3. return (x, y)
 ~~~
 
 ## Mappings for Supersingular curves
@@ -1713,7 +1710,7 @@ Preconditions: A supersingular curve over F such that q=2 (mod 3).
 
 Constants: B, the parameter of the supersingular curve.
 
-Sign of the result: determined by sign of u. No adjustments are necessary.
+Sign of y: determined by sign of u. No adjustments are necessary.
 
 Exceptions: none.
 
@@ -1755,7 +1752,7 @@ Preconditions: A supersingular curve over F such that q=3 (mod 4).
 
 Constants: B, the parameter of the supersingular curve.
 
-Sign of the result: Inputs u and -u give the same x-coordinate.
+Sign of y: Inputs u and -u give the same x-coordinate.
 Thus, we set sgn0(y) == sgn0(u).
 
 Exceptions: none.
@@ -1822,7 +1819,7 @@ Constants:
   g((sqrt(-3 * Z^2) - Z) / 2) is square, breaking ties by choosing
   the positive value.
 
-Sign of the result: Inputs u and -u give the same x-coordinate.
+Sign of y: Inputs u and -u give the same x-coordinate.
 Thus, we set sgn0(y) == sgn0(u).
 
 Exceptions: The exceptional cases for u occur when
@@ -1930,8 +1927,7 @@ Helper functions:
 - map\_to\_curve\_simple\_swu is the mapping of {{simple-swu}} to E'
 - iso\_map is the isogeny map from E' to E
 
-Sign of the result: for this map, the sign is determined by
-map\_to\_curve\_simple\_swu and iso\_map.
+Sign of y: for this map, the sign is determined by map\_to\_curve_elligator2.
 No further sign adjustments are necessary.
 
 Exceptions: map\_to\_curve\_simple\_swu handles its exceptional cases.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1291,10 +1291,10 @@ In general, elliptic curves have equations of the form y^2 = g(x).
 Most of the mappings in this section first identify an x such that
 g(x) is square, then take a square root to find y. Since there
 are two square roots when g(x) != 0, this results in an ambiguity
-regarding the sign of y.
+regarding the sign of the resulting point.
 
 To resolve this ambiguity, the mappings in this section specify
-the sign of the y-coordinate in terms of the input to the mapping function.
+the sign of the resulting point in terms of the input to the mapping function.
 Two main reasons support this approach. First, this covers elliptic curves over
 any field in a uniform way, and second, it gives implementors leeway to optimize
 their square-root implementations.
@@ -1324,8 +1324,8 @@ p=2 (mod 3) and odd m.
 
 Constants: A and B, the parameters of the Weierstrass curve.
 
-Sign of y: this mapping does not compute a square root, so there
-is no ambiguity regarding the sign of y.
+Sign of the result: this mapping does not compute a square root, so there
+is no ambiguity regarding sign.
 
 Exceptions: The only exceptional case is u == 0.
 Implementations must detect this case by testing whether u == 0
@@ -1394,7 +1394,7 @@ Constants:
 - Z, the smallest (in absolute value) non-square in F such that g(B / (Z *
   A)) is square in F, breaking ties by choosing the positive value.
 
-Sign of y: Inputs u and -u give the same x-coordinate.
+Sign of the result: Inputs u and -u give the same x-coordinate.
 Thus, we set sgn0(y) == sgn0(u).
 
 Exceptions: The exceptional cases are values of u such that
@@ -1480,7 +1480,7 @@ Constants:
 - Z, the smallest (in absolute value) non-square in F, breaking ties by choosing
   the positive value.
 
-Sign of y: Inputs u and -u give the same x-coordinate.
+Sign of the result: Inputs u and -u give the same x-coordinate.
 Thus, we set sgn0(y) == sgn0(u).
 
 Exceptions: The exceptional case is Z * u^2 == -1, i.e., 1 + Z * u^2 == 0.
@@ -1677,8 +1677,10 @@ Helper functions:
 - birational\_map is a function that takes a point (x', y') on M and
   returns a point (x, y) on E, as defined in {{birational-map}}.
 
-Sign of y: for this map, the sign is determined by map\_to\_curve\_elligator2.
-No further sign adjustments are required.
+Sign of the result: existing standards may be ambiguous as to the sign
+of the birational map from M to E.
+To ensure consistency across implementations, we fix the sign of the
+result by setting sgn0(x) == sgn0(u) after applying the birational map.
 
 Exceptions: The exceptions for the Elligator 2 mapping are as given in
 {{elligator2}}.
@@ -1695,7 +1697,8 @@ Output: (x, y), a point on E.
 
 1. (x', y') = map_to_curve_elligator2(u)    // (x', y') is on M
 2.   (x, y) = birational_map(x', y')        // (x, y) is on E
-3. return (x, y)
+3. If sgn0(u) != sgn0(x), set x = -x        // fix the sign of the result
+4. return (x, y)
 ~~~
 
 ## Mappings for Supersingular curves
@@ -1710,7 +1713,7 @@ Preconditions: A supersingular curve over F such that q=2 (mod 3).
 
 Constants: B, the parameter of the supersingular curve.
 
-Sign of y: determined by sign of u. No adjustments are necessary.
+Sign of the result: determined by sign of u. No adjustments are necessary.
 
 Exceptions: none.
 
@@ -1752,7 +1755,7 @@ Preconditions: A supersingular curve over F such that q=3 (mod 4).
 
 Constants: B, the parameter of the supersingular curve.
 
-Sign of y: Inputs u and -u give the same x-coordinate.
+Sign of the result: Inputs u and -u give the same x-coordinate.
 Thus, we set sgn0(y) == sgn0(u).
 
 Exceptions: none.
@@ -1819,7 +1822,7 @@ Constants:
   g((sqrt(-3 * Z^2) - Z) / 2) is square, breaking ties by choosing
   the positive value.
 
-Sign of y: Inputs u and -u give the same x-coordinate.
+Sign of the result: Inputs u and -u give the same x-coordinate.
 Thus, we set sgn0(y) == sgn0(u).
 
 Exceptions: The exceptional cases for u occur when
@@ -1927,7 +1930,8 @@ Helper functions:
 - map\_to\_curve\_simple\_swu is the mapping of {{simple-swu}} to E'
 - iso\_map is the isogeny map from E' to E
 
-Sign of y: for this map, the sign is determined by map\_to\_curve_elligator2.
+Sign of the result: for this map, the sign is determined by
+map\_to\_curve\_simple\_swu and iso\_map.
 No further sign adjustments are necessary.
 
 Exceptions: map\_to\_curve\_simple\_swu handles its exceptional cases.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1690,7 +1690,7 @@ Input: u, an element of F.
 Output: (x, y), a point on E.
 
 1. (x', y') = map_to_curve_elligator2(u)    // (x', y') is on M
-2.   (x, y) = rational_map(x', y')        // (x, y) is on E
+2.   (x, y) = rational_map(x', y')          // (x, y) is on E
 3. return (x, y)
 ~~~
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1452,13 +1452,11 @@ Steps:
 
 ## Mappings for Montgomery curves {#montgomery}
 
-### Elligator 2 Method {#elligator2}
-
-The function map\_to\_curve\_elligator2(u) implements Elligator 2 {{BHKL13}} for
+The mapping defined in {{elligator2}} implements Elligator 2 {{BHKL13}} for
 curves defined by the Weierstrass equation y^2 = x^3 + A * x^2 + B * x,
 where A * B * (A^2 - 4 * B) != 0 and A^2 - 4 * B is non-square in F.
 
-The above Weierstrass curve is related to the Montgomery curve
+Such a Weierstrass curve is related to the Montgomery curve
 B' * y'^2 = x'^3 + A' * x'^2 + x' by the following change of variables:
 
 - A = A' / B'
@@ -1474,8 +1472,11 @@ Montgomery curve by computing
 - x' = B' * x
 - y' = B' * y
 
-Note that when B = 1, the above two curve equations are identical;
-this is the case, for example, for Curve25519 and Curve448 {{RFC7748}}.
+Note that when B = 1, the above two curve equations are identical,
+and no conversion is necessary.
+This is the case, for example, for Curve25519 and Curve448 {{RFC7748}}.
+
+### Elligator 2 Method {#elligator2}
 
 Preconditions: A Weierstrass curve y^2 = x^3 + A * x^2 + B * x
 where A != 0, B != 0, and A^2 - 4 * B is non-zero and non-square in F.
@@ -1687,7 +1688,7 @@ Output: (x, y), a point on the equivalent twisted Edwards curve.
 ### Elligator 2 Method {#ell2edwards}
 
 Preconditions: A twisted Edwards curve E and an equivalent curve M, either
-in Montgomery form or in the Weierstrass form given in {{rational-map}}.
+in Montgomery form ({{montgomery}}) or in the Weierstrass form given in {{rational-map}}.
 
 Helper functions:
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1608,6 +1608,9 @@ For both of these curves, {{RFC7748}} lists both the Montgomery and Edwards
 forms and gives the corresponding rational maps
 (for curve25519/edwards25519, Section 4.1; for curve448/edwards448, Section 4.2).
 
+When standardizing new Edwards curves, a Montgomery equivalent and birational
+map SHOULD be specified.
+
 Some Edwards curves lack a standardized Montgomery form or birational map.
 In this case, the following procedure MUST be used to derive a birational map.
 For an Edwards curve given by a * x^2 + y^2 = 1 + d * x^2 * y^2,

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1592,7 +1592,7 @@ Steps:
 ## Mappings for Twisted Edwards curves
 
 Twisted Edwards curves
-(a class of curves that includes "untwisted" Edwards curves)
+(a class of curves that includes Edwards curves)
 are closely related to Montgomery
 curves ({{montgomery}}): every twisted Edwards curve is birationally equivalent
 to a Montgomery curve ({{BBJLP08}}, Theorem 3.2).

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1590,11 +1590,10 @@ curves ({{montgomery}}): every Edwards curve is birationally equivalent
 to a Montgomery curve ({{BBJLP08}}, Theorem 3.2).
 This equivalence yields an efficient way of hashing to an Edwards curve:
 first, hash to the equivalent Montgomery curve, then transform the
-result into a point on the Edwards curve by evaluating a pair of rational
-functions called a birational map.
-This method of hashing to an Edwards curve requires first identifying a
+result into a point on the Edwards curve via a birational map.
+This method of hashing to an Edwards curve thus requires identifying a
 corresponding Montgomery curve and birational map.
-We describe how to identify this curve and map immediately below.
+We describe how to identify such a curve and map immediately below.
 
 ### Birational maps from Montgomery to Twisted Edwards curves {#birational-map}
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1617,7 +1617,7 @@ For an Edwards curve given by a * x^2 + y^2 = 1 + d * x^2 * y^2,
 first compute A and B, the parameters of the equivalent Montgomery curve
 y'^2 = x'^3 + A * x'^2 + B * x', as follows:
 
-- A = (a + 2) / 2
+- A = (a + d) / 2
 - B = (a - d)^2 / 16
 
 Next, let B' = 4 / (a - d). Then the birational map from the point (x', y')

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1583,30 +1583,30 @@ Steps:
 
 ## Mappings for Twisted Edwards curves
 
-Twisted and untwisted Edwards curves
-(which this document refers to generically as Edwards curves)
+Twisted Edwards curves
+(a class of curves that includes "untwisted" Edwards curves)
 are closely related to Montgomery
-curves ({{montgomery}}): every Edwards curve is birationally equivalent
+curves ({{montgomery}}): every twisted Edwards curve is birationally equivalent
 to a Montgomery curve ({{BBJLP08}}, Theorem 3.2).
-This equivalence yields an efficient way of hashing to an Edwards curve:
+This equivalence yields an efficient way of hashing to a twisted Edwards curve:
 first, hash to the equivalent Montgomery curve, then transform the
-result into a point on the Edwards curve via a birational map.
-This method of hashing to an Edwards curve thus requires identifying a
+result into a point on the twisted Edwards curve via a birational map.
+This method of hashing to a twisted Edwards curve thus requires identifying a
 corresponding Montgomery curve and birational map.
 We describe how to identify such a curve and map immediately below.
 
 ### Birational maps from Montgomery to Twisted Edwards curves {#birational-map}
 
 There are two ways to identify the correct Montgomery curve and
-birational map for use when hashing to a given Edwards curve.
+birational map for use when hashing to a given twisted Edwards curve.
 
-When hashing to a standardized Edwards curve for which a corresponding
+When hashing to a standardized twisted Edwards curve for which a corresponding
 Montgomery form and birational map are also standardized, the standard
 Montgomery form and birational map MUST be used to ensure compatibility
 with existing software.
 Two such standardized curves are the edwards25519 and edwards448 curves,
 which correspond to the Montgomery curves curve25519 and curve448, respectively.
-For both of these curves, {{RFC7748}} lists both the Montgomery and Edwards
+For both of these curves, {{RFC7748}} lists both the Montgomery and twisted Edwards
 forms and gives the corresponding rational maps.
 
 The birational map for edwards25519 ({{RFC7748}}, Section 4.1)
@@ -1620,14 +1620,14 @@ k MUST be chosen such that sgn0(k) == 1.
 The 4-isogeny map from curve448 to edwards448 ({{RFC7748}}, Section 4.2)
 is unambiguous with respect to sign.
 
-When defining new Edwards curves, a Montgomery equivalent and birational
+When defining new twisted Edwards curves, a Montgomery equivalent and birational
 map SHOULD be specified, and the sign of the birational map SHOULD be stated
 unambiguously.
 
-When hashing to an Edwards curve that does not have a standardized
+When hashing to a twisted Edwards curve that does not have a standardized
 Montgomery form or birational map, the following procedure MUST be
 used to derive them.
-For an Edwards curve given by a * x^2 + y^2 = 1 + d * x^2 * y^2,
+For a twisted Edwards curve given by a * x^2 + y^2 = 1 + d * x^2 * y^2,
 first compute A and B, the parameters of the equivalent Montgomery curve
 y'^2 = x'^3 + A * x'^2 + B * x', as follows:
 
@@ -1635,13 +1635,14 @@ y'^2 = x'^3 + A * x'^2 + B * x', as follows:
 - B = (a - d)^2 / 16
 
 Next, let B' = 4 / (a - d). Then the birational map from the point (x', y')
-on the Montgomery curve to the point (x, y) on the Edwards curve is given by
+on the Montgomery curve to the point (x, y) on the twisted Edwards curve is
+given by
 
 - x = x' / y'
 - y = (B' * x' - 1) / (B' * x' + 1)
 
 For completeness, we give the inverse map in {{birational-map-inverse}}.
-Note that the inverse map is not used when hashing to an Edwards curve.
+Note that the inverse map is not used when hashing to a twisted Edwards curve.
 
 Note that the above map can be evaluated with just one inversion using
 Montgomery's trick {{M87}}.
@@ -1653,7 +1654,7 @@ rational function is zero.
 For example, in the map described above, the exceptional cases are
 y' == 0 or B' * x' == -1.
 Implementations MUST detect exceptional cases and return the value
-(x, y) = (0, 1), which is a valid point on all Edwards curves
+(x, y) = (0, 1), which is a valid point on all twisted Edwards curves
 given by the equation above.
 
 The following straight-line implementation of the above rational map
@@ -1664,7 +1665,7 @@ are analogous.
 ~~~
 birational_map(x', y')
 Input: (x', y'), a point on a Montgomery curve.
-Output: (x, y), a point on the equivalent Edwards curve.
+Output: (x, y), a point on the equivalent twisted Edwards curve.
 
 1. t1 = y' * B'
 2. t2 = x' + 1
@@ -1699,8 +1700,8 @@ Exceptions: The exceptions for the Elligator 2 mapping are as given in
 The exceptions for the birational map are as given in {{birational-map}}.
 No other exceptions are possible.
 
-The following procedure implements the Elligator 2 mapping for an Edwards
-curve.
+The following procedure implements the Elligator 2 mapping for a twisted
+Edwards curve.
 
 ~~~
 map_to_curve_elligator2_edwards(u)
@@ -2127,7 +2128,7 @@ optimizations.
 Complementary to the problem of mapping from bit strings to elliptic curve
 points, Bernstein et al. {{BHKL13}} study the problem of mapping from elliptic
 curve points to uniformly random bit strings, giving solutions for a class of
-curves including Montgomery and Edwards curves.
+curves including Montgomery and twisted Edwards curves.
 Tibouchi {{T14}} and Aranha et al. {{AFQTZ14}} generalize these results.
 This document does not deal with this complementary problem.
 
@@ -2136,7 +2137,7 @@ This document does not deal with this complementary problem.
 The inverse of the birational map specified in {{birational-map}}, i.e.,
 the map from the point (x', y') on the Montgomery curve
 y'^2 = x'^3 + A * x'^2 + B * x'
-to the point (x, y) on the Edwards curve
+to the point (x, y) on the twisted Edwards curve
 a * x^2 + y^2 = 1 + d * x^2 * y^2
 is given by:
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1590,29 +1590,42 @@ This equivalence yields an efficient way of hashing to an Edwards curve:
 first, hash to the equivalent Montgomery curve, then transform the
 result into a point on the Edwards curve by evaluating a pair of rational
 functions called a birational map.
-Thus, hashing to an Edwards curve requires first identifying a
+This method of hashing to an Edwards curve requires first identifying a
 corresponding Montgomery curve and birational map.
+We describe how to identify this curve and map immediately below.
 
 ### Birational maps from Montgomery to Edwards curves {#birational-map}
 
-There are two ways to identify the Montgomery curve and birational map
-for use with a given Edwards curve.
+There are two ways to identify the correct Montgomery curve and
+birational map for use when hashing to a given Edwards curve.
 
-When hashing to a standard Edwards curves for which a corresponding
+When hashing to a standard Edwards curve for which a corresponding
 Montgomery form and birational map are also standardized, the standard
 Montgomery form and birational map MUST be used to ensure compatibility
 with existing software.
-Two examples of standardized curves are the edwards25519 and edwards448 curves,
+Two such standardized curves are the edwards25519 and edwards448 curves,
 which correspond to the Montgomery curves curve25519 and curve448, respectively.
 For both of these curves, {{RFC7748}} lists both the Montgomery and Edwards
-forms and gives the corresponding rational maps
-(for curve25519/edwards25519, Section 4.1; for curve448/edwards448, Section 4.2).
+forms and gives the corresponding rational maps.
 
-When standardizing new Edwards curves, a Montgomery equivalent and birational
-map SHOULD be specified.
+The birational map for edwards25519 ({{RFC7748}}, Section 4.1)
+uses the constant sqrt\_neg\_486664 = sqrt(-486664) mod 2^255 - 19.
+To ensure compatibility, this constant MUST be chosen such that
+sgn0(sqrt\_neg\_486664) == 1.
+Analogous ambiguities in other standardized birational maps MUST be
+resolved in the same way: for any constant k whose sign is ambiguous,
+k MUST be chosen such that sgn0(k) == 1.
 
-Some Edwards curves lack a standardized Montgomery form or birational map.
-In this case, the following procedure MUST be used to derive a birational map.
+The 4-isogeny map from curve448 to edwards448 ({{RFC7748}}, Section 4.2)
+is unambiguous with respect to sign.
+
+When defining new Edwards curves, a Montgomery equivalent and birational
+map SHOULD be specified, and the sign of the birational map SHOULD be stated
+unambiguously.
+
+When hashing to an Edwards curve that does not have a standardized
+Montgomery form or birational map, the following procedure MUST be
+used to derive them.
 For an Edwards curve given by a * x^2 + y^2 = 1 + d * x^2 * y^2,
 first compute A and B, the parameters of the equivalent Montgomery curve
 y'^2 = x'^3 + A * x'^2 + B * x', as follows:
@@ -1629,7 +1642,7 @@ on the Montgomery curve to the point (x, y) on the Edwards curve is given by
 For completeness, we give the inverse map in {{birational-map-inverse}}.
 Note that the inverse map is not used when hashing to an Edwards curve.
 
-Note that this map can be evaluated with just one inversion using
+Note that the above map can be evaluated with just one inversion using
 Montgomery's trick {{M87}}.
 First, compute t = y' * (B' * x' + 1).
 Then t * y' == 1 / (B' * x' + 1) and t * (B' * x' + 1) == 1 / y'.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1577,42 +1577,42 @@ curves ({{montgomery}}): every twisted Edwards curve is birationally equivalent
 to a Montgomery curve ({{BBJLP08}}, Theorem 3.2).
 This equivalence yields an efficient way of hashing to a twisted Edwards curve:
 first, hash to the equivalent Montgomery curve, then transform the
-result into a point on the twisted Edwards curve via a birational map.
+result into a point on the twisted Edwards curve via a rational map.
 This method of hashing to a twisted Edwards curve thus requires identifying a
-corresponding Montgomery curve and birational map.
+corresponding Montgomery curve and rational map.
 We describe how to identify such a curve and map immediately below.
 
-### Birational maps from Montgomery to Twisted Edwards curves {#birational-map}
+### Rational maps from Montgomery to Twisted Edwards curves {#rational-map}
 
 There are two ways to identify the correct Montgomery curve and
-birational map for use when hashing to a given twisted Edwards curve.
+rational map for use when hashing to a given twisted Edwards curve.
 
 When hashing to a standardized twisted Edwards curve for which a corresponding
-Montgomery form and birational map are also standardized, the standard
-Montgomery form and birational map MUST be used to ensure compatibility
+Montgomery form and rational map are also standardized, the standard
+Montgomery form and rational map MUST be used to ensure compatibility
 with existing software.
 Two such standardized curves are the edwards25519 and edwards448 curves,
 which correspond to the Montgomery curves curve25519 and curve448, respectively.
 For both of these curves, {{RFC7748}} lists both the Montgomery and twisted Edwards
 forms and gives the corresponding rational maps.
 
-The birational map for edwards25519 ({{RFC7748}}, Section 4.1)
+The rational map for edwards25519 ({{RFC7748}}, Section 4.1)
 uses the constant sqrt\_neg\_486664 = sqrt(-486664) mod 2^255 - 19.
 To ensure compatibility, this constant MUST be chosen such that
 sgn0(sqrt\_neg\_486664) == 1.
-Analogous ambiguities in other standardized birational maps MUST be
+Analogous ambiguities in other standardized rational maps MUST be
 resolved in the same way: for any constant k whose sign is ambiguous,
 k MUST be chosen such that sgn0(k) == 1.
 
 The 4-isogeny map from curve448 to edwards448 ({{RFC7748}}, Section 4.2)
 is unambiguous with respect to sign.
 
-When defining new twisted Edwards curves, a Montgomery equivalent and birational
-map SHOULD be specified, and the sign of the birational map SHOULD be stated
+When defining new twisted Edwards curves, a Montgomery equivalent and rational
+map SHOULD be specified, and the sign of the rational map SHOULD be stated
 unambiguously.
 
 When hashing to a twisted Edwards curve that does not have a standardized
-Montgomery form or birational map, the following procedure MUST be
+Montgomery form or rational map, the following procedure MUST be
 used to derive them.
 For a twisted Edwards curve given by a * x^2 + y^2 = 1 + d * x^2 * y^2,
 first compute A and B, the parameters of the equivalent Montgomery curve
@@ -1621,18 +1621,18 @@ y'^2 = x'^3 + A * x'^2 + B * x', as follows:
 - A = (a + d) / 2
 - B = (a - d)^2 / 16
 
-Next, let B' = 4 / (a - d). Then the birational map from the point (x', y')
+Next, let B' = 4 / (a - d). Then the rational map from the point (x', y')
 on the Montgomery curve to the point (x, y) on the twisted Edwards curve is
 given by
 
 - x = x' / y'
 - y = (B' * x' - 1) / (B' * x' + 1)
 
-For completeness, we give the inverse map in {{birational-map-inverse}}.
+For completeness, we give the inverse map in {{rational-map-inverse}}.
 Note that the inverse map is not used when hashing to a twisted Edwards curve.
 
-Birational maps are undefined when the denominator of either
-rational function is zero.
+Rational maps may be undefined, for example, when the denominator of one
+of the rational functions is zero.
 For example, in the map described above, the exceptional cases are
 y' == 0 or B' * x' == -1.
 Implementations MUST detect exceptional cases and return the value
@@ -1645,7 +1645,7 @@ Implementations of other rational maps (e.g., the ones give in {{RFC7748}})
 are analogous.
 
 ~~~
-birational_map(x', y')
+rational_map(x', y')
 Input: (x', y'), a point on a Montgomery curve.
 Output: (x, y), a point on the equivalent twisted Edwards curve.
 
@@ -1665,21 +1665,20 @@ Output: (x, y), a point on the equivalent twisted Edwards curve.
 
 ### Elligator 2 Method {#ell2edwards}
 
-Preconditions: A twisted Edwards curve E and a birationally equivalent
-Montgomery curve M.
+Preconditions: A twisted Edwards curve E and an equivalent Montgomery curve M.
 
 Helper functions:
 
 - map\_to\_curve\_elligator2 is the mapping of {{elligator2}} to the curve M.
-- birational\_map is a function that takes a point (x', y') on M and
-  returns a point (x, y) on E, as defined in {{birational-map}}.
+- rational\_map is a function that takes a point (x', y') on M and
+  returns a point (x, y) on E, as defined in {{rational-map}}.
 
 Sign of y: for this map, the sign is determined by map\_to\_curve\_elligator2.
 No further sign adjustments are required.
 
 Exceptions: The exceptions for the Elligator 2 mapping are as given in
 {{elligator2}}.
-The exceptions for the birational map are as given in {{birational-map}}.
+The exceptions for the rational map are as given in {{rational-map}}.
 No other exceptions are possible.
 
 The following procedure implements the Elligator 2 mapping for a twisted
@@ -1691,7 +1690,7 @@ Input: u, an element of F.
 Output: (x, y), a point on E.
 
 1. (x', y') = map_to_curve_elligator2(u)    // (x', y') is on M
-2.   (x, y) = birational_map(x', y')        // (x, y) is on E
+2.   (x, y) = rational_map(x', y')        // (x, y) is on E
 3. return (x, y)
 ~~~
 
@@ -2114,9 +2113,9 @@ curves including Montgomery and twisted Edwards curves.
 Tibouchi {{T14}} and Aranha et al. {{AFQTZ14}} generalize these results.
 This document does not deal with this complementary problem.
 
-# Birational maps from Twisted Edwards to Montgomery curves {#birational-map-inverse}
+# Rational maps from Twisted Edwards to Montgomery curves {#rational-map-inverse}
 
-The inverse of the birational map specified in {{birational-map}}, i.e.,
+The inverse of the rational map specified in {{rational-map}}, i.e.,
 the map from the point (x', y') on the Montgomery curve
 y'^2 = x'^3 + A * x'^2 + B * x'
 to the point (x, y) on the twisted Edwards curve


### PR DESCRIPTION
This commit separates the description of the birational map from Montgomery to Edwards from the description of the Edwards mapping.

It also clarifies that the correct birational map to use for existing standardized curves is the one from the standard, which addresses a stashed TODO from #107.

This addresses one of the outstanding issues w.r.t. VRF inclusion.