### PR TITLE
Typo

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1257,7 +1257,7 @@ Steps:
 
 # Hashing to a Finite Field {#hashtobase}
 
-The hash\_to\_base(msg) function hashes a string msg of any length into an element of a
+For a given counter ctr the hash\_to\_base(msg, ctr) function hashes a string msg of any length into an element of a
 field F. This function is parametrized by the field F ({{bg-curves}}) and by H,
 a cryptographic hash function that outputs b bits.
 


### PR DESCRIPTION
The `hash_to_base` function has two parameters.

Note: I'm note sure how new lines are determined. It looks like line 1260 is now longer than the others.