### PR TITLE
Avoid rehashing msg

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1355,7 +1355,7 @@ Output:
 - u, an element in F.
 
 Steps:
-1. m' = HKDF-Extract(DST, msg)
+1. m' = HKDF-Extract(DST, H(msg))
 2. for i in (1, ..., m):
 3.   info = "H2C" || I2OSP(ctr, 1) || I2OSP(i, 1)
 4.   t = HKDF-Expand(m', info, L)


### PR DESCRIPTION
`msg` can be large so we want to avoid rehashing it. As I understand it, `HKDF-Extract(DST, msg)` imposes an "arbitrary" hashing of `msg`, namely `H(DST XOR ipad, msg)` where `ipad` is the byte `0x36` repeated 64 times. (See section 2 in [RFC 2104](https://tools.ietf.org/html/rfc2104).) Since various applications will have `H(msg)` readily computed, it makes sense to use `H(msg)` in `HKDF-Extract` as a "natural" way to minimise the chances of hashing `msg` multiple times.