### PR TITLE
roll-up of a few small-ish changes

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -817,6 +817,31 @@ informative:
         ins: K. Bhargavan
         name: Karthikeyan Bhargavan
         org: INRIA Paris
+  DRST12:
+    title: "To hash or not to hash again? (In)differentiability results for H^2 and HMAC"
+    seriesinfo:
+      "In": Advances in Cryptology - CRYPTO 2012
+      "pages": 348-366
+      DOI: 10.1007/978-3-642-32009-5_21
+    target: https://doi.org/10.1007/978-3-642-32009-5_21
+    date: Aug, 2012
+    author:
+      -
+        ins: Y. Dodis
+        name: Yevgeniy Dodis
+        org: New York University
+      -
+        ins: T. Ristenpart
+        name: Thomas Ristenpart
+        org: University of Wisconsin-Madison
+      -
+        ins: J. Steinberger
+        name: John Steinberger
+        org: Tsinghua University
+      -
+        ins: S. Tessaro
+        name: Stefano Tessaro
+        org: Massachusetts Institute of Technology
 
 --- abstract
 
@@ -976,8 +1001,10 @@ construction is distinguishable from uniformly random, i.e., it does
 not behave like a random oracle.
 
 Brier et al. {{BCIMRT10}} describe two generic constructions whose outputs are
-indifferentiable from a random oracle. Farashahi et al. {{FFSTV13}} and
-Tibouchi and Kim {{TK17}} refine the analysis of one of these constructions.
+indifferentiable from a random oracle when the constructions are instantiated
+with appropriate hash functions modeled as random oracles.
+Farashahi et al. {{FFSTV13}} and Tibouchi and Kim {{TK17}} refine the analysis
+of one of these constructions.
 That construction is described in {{roadmap}}.
 
 ### Serialization {#term-serialization}
@@ -1061,8 +1088,8 @@ Steps:
 ~~~
 
 -   Random oracle encoding (hash\_to\_curve). This function encodes bit strings to points in G.
-    This function is suitable for applications requiring a random oracle to G, provided that
-    map\_to\_curve is "well distributed" ({{FFSTV13}}, Def. 1).
+    This function is suitable for applications requiring a random oracle returning points in G,
+    provided that map\_to\_curve is "well distributed" ({{FFSTV13}}, Def. 1).
     All of the map\_to\_curve functions defined in {{mappings}} meet this requirement.
 
 ~~~
@@ -1281,8 +1308,8 @@ a cryptographic hash function H which satisfies the following properties:
 1. The number of bits output by H should be b >= 2 * k for sufficient collision
 resistance, where k is the target security level in bits. (This is needed for a
 birthday bound of approximately 2^(-k).)
-2. H is modeled as a random oracle, so it should be chosen such that its output
-is plausibly indistinguishable from a uniformly random bit string.
+2. H is modeled as a random oracle, so care should be taken when instantiating it.
+Hash functions in the SHA-2 and SHA-3 families are typical and RECOMMENDED choices.
 
 For example, for 128-bit security, b >= 256 bits; in this case, SHA256 would
 be an appropriate choice for H.
@@ -1304,11 +1331,11 @@ for p a 255-bit prime and k = 128-bit security, L = ceil((255 + 128) / 8) = 48 b
 
 Finally, hash\_to\_base sets the input to HKDF to H(msg) rather than to msg.
 This ensures that the use of HKDF in hash\_to\_base is indifferentiable
-from a random oracle (see {{LBB19}}, Appx. A.2).
+from a random oracle (see {{LBB19}}, Lemma 8 and {{DRST12}}, Theorems 4.3 and 4.4).
 (In particular, as long as the output length of H is greater than 48
-bits---which will always be true in practice---the inputs to HKDF-Extract
-and HKDF-Expand are guaranteed to be disjoint, since they are of different
-lengths.)
+bits---which will always be true in practice---the inputs to the HMAC
+invocations inside HKDF-Extract and HKDF-Expand are guaranteed to be
+disjoint, since they are of different lengths.)
 
 {{domain-separation}} discusses requirements for domain separation and
 recommendations for choosing domain separation tags. The hash\_to\_curve
@@ -2377,7 +2404,7 @@ should be chosen according to the guidelines listed in {{hashtobase-sec}}.
 
 The authors would like to thank Adam Langley for his detailed writeup of Elligator 2 with
 Curve25519 {{L13}};
-Chris Patton for educational discussions on the security of domain separation; and
+Christopher Patton for educational discussions on the security of domain separation; and
 Sean Devlin, Justin Drake, Dan Harkins, Thomas Icart, and Mathy Vanhoef for helpful feedback.
 
 # Contributors

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2363,9 +2363,10 @@ for random oracle encodings.
 
 # Acknowledgements
 
-The authors would like to thank Adam Langley for his detailed writeup up Elligator 2 with
-Curve25519 {{L13}}. We also thank Sean Devlin and Thomas Icart for feedback on
-earlier versions of this document.
+The authors would like to thank Adam Langley for his detailed writeup of Elligator 2 with
+Curve25519 {{L13}};
+Chris Patton for educational discussions on the security of domain separation; and
+Sean Devlin, Justin Drake, Dan Harkins, and Thomas Icart for their careful feedback.
 
 # Contributors
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -976,7 +976,7 @@ construction is distinguishable from uniformly random, i.e., it does
 not behave like a random oracle.
 
 Brier et al. {{BCIMRT10}} describe two generic constructions whose outputs are
-indistinguishable from a random oracle. Farashahi et al. {{FFSTV13}} and
+indifferentiable from a random oracle. Farashahi et al. {{FFSTV13}} and
 Tibouchi and Kim {{TK17}} refine the analysis of one of these constructions.
 That construction is described in {{roadmap}}.
 
@@ -1061,8 +1061,8 @@ Steps:
 ~~~
 
 -   Random oracle encoding (hash\_to\_curve). This function encodes bit strings to points in G.
-    The distribution of the output is indistinguishable from uniformly random
-    in G provided that map\_to\_curve is "well distributed" ({{FFSTV13}}, Def. 1).
+    This function is suitable for applications requiring a random oracle to G, provided that
+    map\_to\_curve is "well distributed" ({{FFSTV13}}, Def. 1).
     All of the map\_to\_curve functions defined in {{mappings}} meet this requirement.
 
 ~~~

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2364,12 +2364,21 @@ for random oracle encodings.
 
 {{hashtobase}} describes considerations for uniformly hashing to field elements.
 
+When hashing passwords using any function described in this document, an adversary
+who learns the output of the hash function (or potentially any intermediate value,
+e.g., the output of hash\_to\_base) may be able to carry out a dictionary attack.
+To mitigate such attacks, it is recommended to first execute a more costly key
+derivation function (e.g., scrypt {{!RFC7914}}) on the password, then hash the
+output of that function to the target elliptic curve.
+For collision resistance, the hash underlying the key derivation function
+should be chosen according to the guidelines listed in {{hashtobase-sec}}.
+
 # Acknowledgements
 
 The authors would like to thank Adam Langley for his detailed writeup of Elligator 2 with
 Curve25519 {{L13}};
 Chris Patton for educational discussions on the security of domain separation; and
-Sean Devlin, Justin Drake, Dan Harkins, and Thomas Icart for their careful feedback.
+Sean Devlin, Justin Drake, Dan Harkins, Thomas Icart, and Mathy Vanhoef for helpful feedback.
 
 # Contributors
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2101,7 +2101,10 @@ In addition to the above parameters, the mapping f may require
 additional parameters Z, M, rational\_map, E', and/or iso\_map.
 These MUST be specified when applicable.
 
-Applications whose security requires a random oracle MUST use
+All applications MUST choose a domain separation tag (DST)
+for use with hash\_to\_base ({{hashtobase}}), in accordance with the
+guidelines of {{domain-separation}}.
+In addition, applications whose security requires a random oracle MUST use
 a suite specifying hash\_to\_curve ({{roadmap}}); see {{suiteIDformat}}.
 
 When standardizing a new elliptic curve, corresponding hash-to-curve

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -485,7 +485,7 @@ informative:
       -
         ins: A. Langley
         name: Adam Langley
-  SBCDBK09:
+  SBCDK09:
     title: Fast Hashing to G2 on Pairing-Friendly Curves
     seriesinfo:
         "In": Pairing-Based Cryptography - Pairing 2009
@@ -509,10 +509,6 @@ informative:
       -
         ins: L. J. Dominguez Perez
         name: Luis J. Dominguez Perez
-        org: School of Computing Dublin City University, Ballymun. Dublin, Ireland.
-      -
-        ins: N. Benger
-        name: Naomi Benger
         org: School of Computing Dublin City University, Ballymun. Dublin, Ireland.
       -
         ins: E. J. Kachisa
@@ -2028,7 +2024,7 @@ some scalar h\_eff whose value is determined by the method and the curve.
 Examples of fast cofactor clearing methods include the following:
 
 - For certain pairing-friendly curves having subgroup G2 over an extension
-  field, Scott et al. {{SBCDBK09}} describe a method for fast cofactor clearing
+  field, Scott et al. {{SBCDK09}} describe a method for fast cofactor clearing
   that exploits an efficiently-computable endomorphism. Fuentes-Castaneda
   et al. {{FKR11}} propose an alternative method that is sometimes more efficient.
   Budroni and Pintore {{BP18}} give concrete instantiations of these methods

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -828,6 +828,12 @@ We provide implementation details for each algorithm, describe
 the security rationale behind each recommendation, and give guidance for
 elliptic curves that are not explicitly covered.
 
+This document does not cover rejection sampling methods, sometimes known
+as "try-and-increment" or "hunt-and-peck," because the goal is to describe
+algorithms that can plausibly be made constant time. Use of these rejection
+methods is NOT RECOMMENDED, because they have been a perennial cause of
+side-channel vulnerabilities.
+
 ## Requirements
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1132,26 +1132,29 @@ Implementors MUST observe the following guidelines:
 1. Tags must be supplied as the DST parameter to hash\_to\_base, as
    described in {{hashtobase}}.
 
-2. Tags should begin with a fixed protocol identification string.
+2. Tags must begin with a fixed protocol identification string.
    This identification string should be unique to the protocol.
 
-3. Tags should include a protocol version number.
+3. Tags must include a protocol version number.
 
-4. For protocols that support multiple ciphersuites, tags must include
-   a ciphersuite identifier.
+4. For protocols that define multiple ciphersuites, each ciphersuite's
+   tag must be different. For this purpose, it is recommended to
+   include a ciphersuite identifier in each tag.
 
-As an example, consider a fictional key exchange protocol named Quux.
+5. For protocols that use multiple encodings, either to the same curve
+   or to different curves, each encoding must use a different tag.
+
+As an example, consider a fictional key exchange protocol named Quux
+that defines several different ciphersuites.
 A reasonable choice of tag is "QUUX-V\<xx\>-CS\<yy\>", where \<xx\> and \<yy\>
 are two-digit numbers indicating the version and ciphersuite, respectively.
 
 As another example, consider a fictional protocol named Baz that requires
-two independent random oracles, where one oracle outputs points on the curve E1
-and the other outputs points on the curve E2.
-To ensure that these two random oracles are independent, each one must be
-called with a distinct domain separation tag.
+two independent random oracles, where one oracle outputs points on the curve
+E1 and the other outputs points on the curve E2.
 Reasonable choices of tags for the E1 and E2 oracles are
 "BAZ-V\<xx\>-CS\<yy\>-E1" and "BAZ-V\<xx\>-CS\<yy\>-E2", respectively,
-where \<xx\> and \<yy\> are as defined above.
+where \<xx\> and \<yy\> are as described above.
 
 # Utility Functions {#utility}
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2414,8 +2414,11 @@ with hash\_to\_base ({{hashtobase}}), the resulting function is
 indifferentiable from a random oracle.
 In most cases such a function can be safely used in protocols whose security
 analysis assumes a random oracle that outputs points on an elliptic curve.
-As Ristenpart et al. discuss in {{RSS11}}, however, the indifferentiability
-framework has limitations which must be considered when analyzing security.
+As Ristenpart et al. discuss in {{RSS11}}, however, not all security proofs
+that rely on random oracles continue to hold when those oracles are replaced
+by indifferentiable functionalities.
+This limitation should be considered when analyzing the security of protocols
+relying on the hash\_to\_curve function.
 
 When hashing passwords using any function described in this document, an adversary
 who learns the output of the hash function (or potentially any intermediate value,


### PR DESCRIPTION
This PR addresses a few TODOs from my list.

The most major one is that it addresses @cjpatton's suggestions regarding domain separation.

It also rolls in suggestions from @JustinDrake and @vanhoefm, and fixes some small editorial nits.

Oh, and it updates the acknowledgment sections.