### PR TITLE
make sgn0 definition per-suite ; improve descriptions of sgn0 and sqrt functions

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2253,6 +2253,7 @@ Each suite comprises the following parameters:
 - E, the target elliptic curve over a field F.
 - p, the characteristic of the field F.
 - m, the extension degree of the field F.
+- sgn0, one of the variants specified in {{sgn0-variants}}.
 - H, the hash function used by hash\_to\_base ({{hashtobase-sec}}).
 - L, the length of HKDF-Expand output in hash\_to\_base ({{hashtobase-sec}}).
 - f, a mapping function from {{mappings}}.
@@ -2347,6 +2348,7 @@ The common parameters for the above suites are:
    - B = 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b
 - p: 2^256 - 2^224 + 2^192 + 2^96 - 1
 - m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
 - H: SHA-256
 - L: 48
 - h\_eff: 1
@@ -2377,6 +2379,7 @@ The common parameters for the above suites are:
   - B = 0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef
 - p: 2^384 - 2^128 - 2^96 + 2^32 - 1
 - m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
 - H: SHA-512
 - L: 72
 - h\_eff: 1
@@ -2404,6 +2407,7 @@ The common parameters for the above suites are:
   - B = 0x51953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00
 - p: 2^521 - 1
 - m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
 - H: SHA-512
 - L: 96
 - h\_eff: 1
@@ -2434,6 +2438,7 @@ The common parameters for all of the above suites are:
 
 - p: 2^255 - 19
 - m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
 - H: SHA-256
 - L: 48
 - Z: 2
@@ -2468,6 +2473,7 @@ The common parameters for all of the above suites are:
 
 - p: 2^448 - 2^224 - 1
 - m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
 - H: SHA-512
 - L: 84
 - Z: -1
@@ -2501,6 +2507,7 @@ The common parameters for all of the above suites are:
 - E: y^2 = x^3 + 7
 - p: 2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1
 - m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
 - H: SHA-256
 - L: 48
 - h\_eff: 1
@@ -2533,6 +2540,7 @@ The common parameters for the above suites are:
 - E: y^2 = x^3 + 4
 - p: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
 - m: 1
+- sgn0: sgn0\_be ({{sgn0-be}})
 - H: SHA-256
 - L: 64
 - h\_eff: 0xd201000000010001
@@ -2568,6 +2576,7 @@ The common parameters for the above suites are:
 
 - E: y^2 = x^3 + 4 * (1 + I)
 - p, m, F: defined above
+- sgn0: sgn0\_be ({{sgn0-be}})
 - H: SHA-256
 - L: 64
 - h\_eff: 0xbc69f08f2ee75b3584c6a0ea91b352888e2a8e9145ad7689986ff031508ffe1329c2f178731db956d82bf015d1212b02ec0ec69d7477c1ae954cbc06689f6a359894c0adebbf6b4e8020005aaa95551

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -957,10 +957,10 @@ an integer m > 1. This document writes elements of field extensions
 in a primitive element or polynomial basis, i.e., as a vector
 of m elements of GF(p) written in ascending order by degree.
 The entries of this vector are indexed in ascending order starting from 1,
-i.e., x = (x_1, x_2, ..., x_m).
+i.e., x = (x\_1, x\_2, ..., x\_m).
 For example, if q = p^2 and the primitive element basis is (1, i),
 then x = (a, b) corresponds to the element a + b * i, where
-x_1 = a and x_2 = b.
+x\_1 = a and x\_2 = b.
 
 An elliptic curve E is specified by an equation in two variables and a
 finite field F. An elliptic curve equation takes one of several standard forms,
@@ -1293,8 +1293,16 @@ element of F.
 It is convenient for hash-to-curve and decompression to agree on a notion of
 sign, since this may permit simpler implementations.
 
-See {{bg-curves}} for a discussion of representing x as a vector; this
-representation is used in both of the variants immediately below.
+See {{bg-curves}} for a discussion of representing elements of field extensions
+as vectors; this representation is used in both of the sgn0 variants below.
+
+Note that any valid sgn0 function for field extensions must iterate over
+the entire vector representation of the input element.
+To see why, imagine a function sgn0\* that ignores the final entry in its
+input vector, and consider a field element x = (0, 0, 0, 0, x\_5).
+Since sgn0\* ignores x\_5, sgn0\*(x) == sgn0\*(-x) == 1, which is incorrect
+when x\_5 != 0.
+The same argument applies to all entries of x, establishing the claim.
 
 ### Big endian variant {#sgn0-be}
 
@@ -2111,7 +2119,7 @@ Helper functions:
 - map\_to\_curve\_simple\_swu is the mapping of {{simple-swu}} to E'
 - iso\_map is the isogeny map from E' to E
 
-Sign of y: for this map, the sign is determined by map\_to\_curve_elligator2.
+Sign of y: for this map, the sign is determined by map\_to\_curve\_elligator2.
 No further sign adjustments are necessary.
 
 Exceptions: map\_to\_curve\_simple\_swu handles its exceptional cases.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -3339,14 +3339,11 @@ Procedure:
 6.  for k in (m, m - 1, ..., 2):
 7.      for j in (1, 2, ..., k - 1):
 8.           b = b * b
-9.      b_is_good = b != 1
-10.     tmp = r * c
-11.     r = CMOV(r, tmp, e)
-12.     c = c * c
-13.     tmp = t * c
-14.     t = CMOV(t, tmp, e)
-15.     b = t
-16. return r
+9.      r = CMOV(r, r * c, b != 1)
+10.     c = c * c
+11.     t = CMOV(t, t * c, b != 1)
+12.     b = t
+13. return r
 ~~~
 
 The constants used in this procedure can be computed as follows:

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -930,11 +930,14 @@ For further reference on elliptic curves, consult {{CFADLNV05}} or {{W08}}.
 
 Let F be the finite field GF(q) of prime characteristic p. In most cases F
 is a prime field, so q = p. Otherwise, F is a field extension, so q = p^m for
-an integer m > 1. This document assumes that elements of field extensions
-are written in a primitive element or polynomial basis, i.e., as
-of m elements of GF(p) written in ascending order
-by degree. For example, if q = p^2 and the primitive element basis is {1, i},
-then the vector (a, b) corresponds to the element a + b * i.
+an integer m > 1. This document writes elements of field extensions
+in a primitive element or polynomial basis, i.e., as a vector
+of m elements of GF(p) written in ascending order by degree.
+The entries of this vector are indexed in ascending order starting from 1,
+i.e., x = (x_1, x_2, ..., x_m).
+For example, if q = p^2 and the primitive element basis is (1, i),
+then x = (a, b) corresponds to the element a + b * i, where
+x_1 = a and x_2 = b.
 
 An elliptic curve E is specified by an equation in two variables and a
 finite field F. An elliptic curve equation takes one of several standard forms,
@@ -1308,8 +1311,8 @@ Steps:
 ### Little endian variant {#sgn0-le}
 
 The following sgn0 variant is defined such that sgn0\_le(x) = -1
-just when the parity of the least significant nonzero entry of the
-vector representation of x is 1.
+just when x != 0 and the parity of the least significant nonzero
+entry of the vector representation of x is 1.
 
 This variant is convenient when points are serialized
 in little-endian byte order.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1281,17 +1281,17 @@ is_square(x) := { True,  if x^((q - 1) / 2) is 0 or 1 in F;
 
 This section defines two ways of determining the "sign" of an element of F.
 The variant that should be used is a matter of convention.
-Other sgn0 variants are possible, but the two given below appear to cover
-all commonly used notions of sign.
+Other sgn0 variants are possible, but the two given below cover
+commonly used notions of sign.
 
-It is recommended to select the variant that matches the point decompression
+It is RECOMMENDED to select the variant that matches the point decompression
 method of the target curve.
 In particular, since point decompression requires computing a square root
 and then choosing the sign of the resulting point, all decompression methods
 specify, implicitly or explicitly, a method for determining the sign of an
 element of F.
 It is convenient for hash-to-curve and decompression to agree on a notion of
-sign, since this potentially allows for simpler implementations.
+sign, since this may permit simpler implementations.
 
 See {{bg-curves}} for a discussion of representing x as a vector; this
 representation is used in both of the variants immediately below.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -76,7 +76,7 @@ informative:
         ins: T. Saito
         name: Tsunekazu Saito
         org: NTT
-  SECG1:
+  SEC1:
     title: "SEC 1: Elliptic Curve Cryptography"
     target: http://www.secg.org/sec1-v2.pdf
     date: May, 2009
@@ -749,9 +749,13 @@ informative:
   WB19:
     title: Fast and simple constant-time hashing to the BLS12-381 elliptic curve
     seriesinfo:
-        "Technical report": ePrint 2019/403
+        "In": IACR Trans. CHES
+        "volume": 2019
+        "issue": 4
+        DOI: 10.13154/tches.v2019.i4.154-179
+        "ePrint": 2019/403
     target: https://eprint.iacr.org/2019/403
-    date: 2019
+    date: Aug, 2019
     author:
       -
         ins: R. S. Wahby
@@ -889,6 +893,14 @@ informative:
     author:
       -
         org: IEEE Computer Society
+  x9.62:
+    title: "Public Key Cryptography for the Financial Services Industry: the Elliptic Curve Digital Signature Algorithm (ECDSA)"
+    date: Sep, 1998
+    seriesinfo:
+      "ANSI": X9.62-1998
+    author:
+      -
+        org: ANSI
 
 --- abstract
 
@@ -1061,9 +1073,8 @@ That construction is described in {{roadmap}}.
 
 A procedure related to encoding is the conversion of an elliptic curve point to a bit string.
 This is called serialization, and is typically used for compactly storing or transmitting points.
-For example, {{SECG1}} gives a standard method for serializing points.
-The reverse operation, deserialization, converts a bit string to an elliptic
-curve point.
+The reverse operation, deserialization, converts a bit string to an elliptic curve point.
+For example, {{SEC1}} and {{p1363a}} give standard methods for serialization and deserialization.
 
 Deserialization is different from encoding in that only certain strings
 (namely, those output by the serialization procedure) can be deserialized.
@@ -1291,10 +1302,9 @@ The following sgn0 variant is defined such that sgn0\_be(x) = -1
 just when the big-endian encoding of x is lexically greater than
 the encoding of -x.
 
-This variant is convenient when points are serialized
-in big-endian byte order, or when points are serialized
-according to IEEE 1363a-2004 {{p1363a}} and the extension
-degree of F is greater than 1.
+This variant SHOULD be used when points on the target elliptic curve
+are serialized using the SORT compression method given in
+IEEE 1363a-2004 {{p1363a}}, Section 5.5.6.1.2, and other similar methods.
 
 ~~~
 sgn0_be(x)
@@ -1324,13 +1334,15 @@ The following sgn0 variant is defined such that sgn0\_le(x) = -1
 just when x != 0 and the parity of the least significant nonzero
 entry of the vector representation of x is 1.
 
-This variant is convenient when points are serialized
-in little-endian byte order.
-For example, this serialization is specified for the
+This variant SHOULD be used when points on the target elliptic curve are serialized
+using any of the following methods:
+
+- the LSB compression method given in IEEE 1363a-2004 {{p1363a}}, Section 5.5.6.1.1,
+- the method given in {{SEC1}} Section 2.3.3, or
+- the method given in ANSI X9.62-1998 {{x9.62}}, Section 4.2.1.
+
+This variant is also compatible with the compression method specified for the
 Ed25519 and Ed448 elliptic curves {{!RFC8032}}.
-This variant is also convenient when points are serialized
-according to IEEE 1363a-2004 {{p1363a}} and the extension
-degree of F is exactly 1.
 
 ~~~
 sgn0_le(x)

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1229,69 +1229,9 @@ is_square(x) := { True,  if x^((q - 1) / 2) is 0 or 1 in F;
 
     The preferred way of computing square roots is to fix a deterministic
     algorithm particular to F. We give algorithms for the three most common
-    cases immediately below; other cases are analogous.
-
-    Note that Case 3 below applies to GF(p^2) when p = 3 (mod 8).
-    {{AR13}} and {{S85}} describe methods that work for other field extensions.
-    Regardless of the method chosen, the sqrt function MUST be performed in
-    constant time.
-
-~~~
-s = sqrt(x)
-
-Parameters:
-- F, a finite field of characteristic p and order q = p^m, m >= 1.
-
-Input: x, an element of F.
-Output: s, an element of F such that (s^2) == x.
-
-======
-
-Case 1: q = 3 (mod 4)
-
-Constants:
-1. c1 = (q + 1) / 4     // Integer arithmetic
-
-Procedure:
-1. return x^c1
-
-======
-
-Case 2: q = 5 (mod 8)
-
-Constants:
-1. c1 = sqrt(-1) in F, i.e., (c1^2) == -1 in F
-2. c2 = (q + 3) / 8     // Integer arithmetic
-
-Procedure:
-1. t1 = x^c2
-2.  e = (t1^2) == x
-3.  s = CMOV(t1 * c1, t1, e)
-3. return s
-
-======
-
-Case 3: q = 9 (mod 16)
-
-Constants:
-1. c1 = sqrt(-1) in F, i.e., (c1^2) == -1 in F
-2. c2 = sqrt(c1) in F, i.e., (c2^2) == c1 in F
-3. c3 = sqrt(-c1) in F, i.e., (c3^2) == -c1 in F
-4. c4 = (q + 7) / 16    // Integer arithmetic
-
-Procedure:
-1.  t1 = x^c4
-2.  t2 = c1 * t1
-3.  t3 = c2 * t1
-4.  t4 = c3 * t1
-5.  e1 = (t2^2) == x
-6.  e2 = (t3^2) == x
-7.  t1 = CMOV(t1, t2, e1)  // Select t2 if (t2^2) == x
-8.  t2 = CMOV(t4, t3, e2)  // Select t3 if (t3^2) == x
-9.  e3 = (t2^2) == x
-10.  s = CMOV(t1, t2, e3)  // Select the sqrt from t1 and t2
-11. return s
-~~~
+    cases in {{sqrt-variants}}.
+    Regardless of the method chosen, the sqrt function should be implemented
+    in a way that resists timing side channels, i.e., in constant time.
 
 -   sgn0(x): This function returns either +1 or -1 indicating the "sign" of x,
     where sgn0(x) == -1 just when x is "negative".
@@ -1399,6 +1339,91 @@ Steps:
 4.   sign_i = CMOV(sign_i, 0, x_i == 0)
 5.   sign = CMOV(sign, sign_i, sign == 0)
 6. return CMOV(sign, 1, sign == 0)     // regard x == 0 as positive
+~~~
+
+## sqrt variants {#sqrt-variants}
+
+This section defines sqrt for the three most common cases:
+p = 3 (mod 4), p = 5 (mod 8), and p = 9 (mod 16).
+
+### p = 3 mod 4 {#sqrt-3mod4}
+
+~~~
+sqrt_3mod4(x)
+
+Parameters:
+- F, a finite field of characteristic p and order q = p^m.
+- p, the characteristic of F (see immediately above).
+- m, the extension degree of F, m >= 1 (see immediately above).
+
+Input: x, an element of F.
+Output: s, an element of F such that (s^2) == x.
+
+Constants:
+1. c1 = (q + 1) / 4     // Integer arithmetic
+
+Procedure:
+1. return x^c1
+~~~
+
+### p = 5 mod 8 {#sqrt-5mod8}
+
+~~~
+sqrt_5mod8(x)
+
+Parameters:
+- F, a finite field of characteristic p and order q = p^m.
+- p, the characteristic of F (see immediately above).
+- m, the extension degree of F, m >= 1 (see immediately above).
+
+Input: x, an element of F.
+Output: s, an element of F such that (s^2) == x.
+
+Constants:
+1. c1 = sqrt(-1) in F, i.e., (c1^2) == -1 in F
+2. c2 = (q + 3) / 8     // Integer arithmetic
+
+Procedure:
+1. t1 = x^c2
+2.  e = (t1^2) == x
+3.  s = CMOV(t1 * c1, t1, e)
+3. return s
+~~~
+
+### p = 9 mod 16 {#sqrt-9mod16}
+
+Note that this case also applies to GF(p^2) when p = 3 (mod 8).
+{{AR13}} and {{S85}} describe methods that work for other field extensions.
+
+~~~
+sqrt_9mod16(x)
+
+Parameters:
+- F, a finite field of characteristic p and order q = p^m.
+- p, the characteristic of F (see immediately above).
+- m, the extension degree of F, m >= 1 (see immediately above).
+
+Input: x, an element of F.
+Output: s, an element of F such that (s^2) == x.
+
+Constants:
+1. c1 = sqrt(-1) in F, i.e., (c1^2) == -1 in F
+2. c2 = sqrt(c1) in F, i.e., (c2^2) == c1 in F
+3. c3 = sqrt(-c1) in F, i.e., (c3^2) == -c1 in F
+4. c4 = (q + 7) / 16    // Integer arithmetic
+
+Procedure:
+1.  t1 = x^c4
+2.  t2 = c1 * t1
+3.  t3 = c2 * t1
+4.  t4 = c3 * t1
+5.  e1 = (t2^2) == x
+6.  e2 = (t3^2) == x
+7.  t1 = CMOV(t1, t2, e1)  // Select t2 if (t2^2) == x
+8.  t2 = CMOV(t4, t3, e2)  // Select t3 if (t3^2) == x
+9.  e3 = (t2^2) == x
+10.  s = CMOV(t1, t2, e3)  // Select the sqrt from t1 and t2
+11. return s
 ~~~
 
 # Hashing to a Finite Field {#hashtobase}
@@ -1512,7 +1537,7 @@ Steps:
 3. for i in (1, ..., m):
 4.   info = info_pfx || I2OSP(i, 1)
 5.   t = HKDF-Expand(msg_prime, info, L)
-6.   e_i = OS2IP(t) (mod p)
+6.   e_i = OS2IP(t) mod p
 7. u = (e_1, ..., e_m)
 8. return u
 ~~~

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -477,6 +477,10 @@ informative:
     title: Hashing to Elliptic Curves - GitHub repository
     target: https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve
     date: 2019
+  jubjub-fq:
+    title: zkcrypto/jubjub - fq.rs
+    target: https://github.com/zkcrypto/jubjub/blob/master/src/fq.rs
+    date: 2019
   L13:
     title: Implementing Elligator for Curve25519
     target: https://www.imperialviolet.org/2013/12/25/elligator.html
@@ -3314,7 +3318,7 @@ Procedure:
 ## Constant-time Tonelli-Shanks algorithm {#sqrt-ts}
 
 This algorithm is a constant-time version of the classic Tonelli-Shanks algorithm
-({{C93}}, Algorithm 1.5.1) due to Sean Bowe, Jack Grigg, and Eirik Ogilvie-Wigley,
+({{C93}}, Algorithm 1.5.1) due to Sean Bowe, Jack Grigg, and Eirik Ogilvie-Wigley {{jubjub-fq}},
 adapted and optimized by Michael Scott.
 
 This algorithm applies to GF(p) for any p.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1299,10 +1299,10 @@ as vectors; this representation is used in both of the sgn0 variants below.
 Note that any valid sgn0 function for field extensions must iterate over
 the entire vector representation of the input element.
 To see why, imagine a function sgn0\* that ignores the final entry in its
-input vector, and consider a field element x = (0, 0, 0, 0, x\_5).
-Since sgn0\* ignores x\_5, sgn0\*(x) == sgn0\*(-x) == 1, which is incorrect
-when x\_5 != 0.
-The same argument applies to all entries of x, establishing the claim.
+input vector, and consider a field element x = (0, x\_2).
+Since sgn0\* ignores x\_2, sgn0\*(x) == sgn0\*(-x), which is incorrect
+when x\_2 != 0.
+The same argument applies to all entries of any x, establishing the claim.
 
 ### Big endian variant {#sgn0-be}
 


### PR DESCRIPTION
This patch does three (roughly) related things:

1. It defines two variants of sgn0, "little endian" (LE) and "big endian" (BE).
  - LE is a generalization of IEEE P1363a-2004 Section 5.5.6.1.1, ANSI X9.62-1998, Section 4.2.1, and [SEC 1 Section 2.3.3](https://secg.org/sec1-v2.pdf). (All three of these use the same notion of sign: the value of the least significant bit.)
      
      This is the notion of sign used by most widely-deployed curves. For example, it's the one specified in RFC 8032 (Sections 5.1.3 and 5.2.3) and the one used in TLS (per [RFC 4492, Section 5.1.2](https://tools.ietf.org/html/rfc4492#section-5.1.2)).

  - BE is equivalent to the method given in IEEE P1363a-2004, Section 5.5.6.1.2.

      This is the form used by [BLS12-381](https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md), and is the same as what we used to call sgn0.

2. It adds a sgn0 parameter to each suite that specifies which sgn0 function to use. All suites use sgn0_le except BLS12-381, which corresponds with widely-used notions of sign for each curve.

3. It clarifies the sqrt functions and gives a constant-time version of Tonelli-Shanks (which works for any p) due to Sean Bowe, Jack Grigg, Eirik Ogilvie-Wigley, and Michael Scott. It also moves these to the appendix, since we treat sqrt as non-normative (in particular, we don't care about how implementors compute the sign).