### PR TITLE
Clarifications around S-SWU map

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1670,11 +1670,10 @@ Operations:
 
 #### Implementation
 
-The following procedure implements the simplified SWU mapping in a
-straight-line fashion.
+The following procedure implements the simplified SWU mapping in a straight-line fashion.
 {{samplecode}} gives an optimized straight-line procedure for P-256 {{FIPS186-4}}.
-For discussion of how to generalize to q = 1 (mod 4), see
-{{WB19}} (Section 4) or the example code found at {{hash2curve-repo}}.
+For more information on optimizing this mapping, see
+{{WB19}} Section 4 or the example code found at {{hash2curve-repo}}.
 
 ~~~
 map_to_curve_simple_swu(u)


### PR DESCRIPTION
This is a small cleanup:

- Clarify some text regarding optimized S-SWU implementations.
- Rename "S-SWU for pairing-friendly" to "S-SWU for AB==0", since it's not really limited to pairing-friendly curves.
- Move the renamed S-SWU,AB==0 section to the Weierstrass subsection of the mappings section.