### PR TITLE
clarifications in document

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -3141,9 +3141,8 @@ Output: (xn, xd, yn, yd) such that (xn / xd, yn / yd) is a
         point on the target curve.
 
 Constants: defined per curve; see above.
-1.  c1 = B / 3
-2.  c2 = (p - 3) / 4           // Integer arithmetic
-3.  c3 = sqrt(-Z^3)
+1.  c1 = (p - 3) / 4           // Integer arithmetic
+2.  c2 = sqrt(-Z^3)
 
 Steps:
 1.   t1 = u^2
@@ -3166,10 +3165,10 @@ Steps:
 18.  t4 = gxd^2
 19.  t2 = gx1 * gxd
 20.  t4 = t4 * t2              // gx1 * gxd^3
-21.  y1 = t4^c2                // (gx1 * gxd^3)^((p - 3) / 4)
+21.  y1 = t4^c1                // (gx1 * gxd^3)^((p - 3) / 4)
 22.  y1 = y1 * t2              // gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
 23. x2n = t3 * x1n             // x2 = x2n / xd = -10 * u^2 * x1n / xd
-24.  y2 = y1 * c3              // y2 = y1 * sqrt(-Z^3)
+24.  y2 = y1 * c2              // y2 = y1 * sqrt(-Z^3)
 25.  y2 = y2 * t1
 26.  y2 = y2 * u
 27.  t2 = y1^2

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2016,7 +2016,7 @@ Operations:
 
 ~~~
 1.  X1 = -C * inv0(1 + Z * u^2)
-2.  If X1 == 0, set X1 = -C.
+2.  If X1 == 0, set X1 = -C
 3. gX1 = X1^3 + C * X1^2 + D * X1
 4.  X2 = -X1 - C
 5. gX2 = X2^3 + C * X2^2 + D * X2
@@ -2295,7 +2295,7 @@ Operations:
 4. gX2 = -gX1
 5. If is_square(gX1), set X = X1 and Y = sqrt(gX1)
 6. Else set X = X2 and Y = sqrt(gX2)
-7. If sgn0(u) != sgn0(Y), set Y = -Y.
+7. If sgn0(u) != sgn0(Y), set Y = -Y
 8. return (X, Y)
 ~~~
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2519,7 +2519,7 @@ This section defines ciphersuites for curve25519 and edwards25519 {{RFC7748}}.
 The suites curve25519-SHA256-ELL2-RO- and curve25519-SHA256-ELL2-NU-
 share the following parameters, in addition to the common parameters below.
 
-- E: B * y^2 = x^3 + A * x^2 + x, where
+- E: B * t^2 = s^3 + A * s^2 + s, where
   - A = 486662
   - B = 1
 - f: Elligator 2 method, {{elligator2}}
@@ -2527,7 +2527,7 @@ share the following parameters, in addition to the common parameters below.
 The suites edwards25519-SHA256-EDELL2-RO- and edwards25519-SHA256-EDELL2-NU-
 share the following parameters, in addition to the common parameters below.
 
-- E: a * x^2 + y^2 = 1 + d * x^2 * y^2, where
+- E: a * v^2 + w^2 = 1 + d * v^2 * w^2, where
   - a = -1
   - d = 0x52036cee2b6ffe738cc740797779e89800700a4d4141d8ab75eb4dca135978a3
 - f: Twisted Edwards Elligator 2 method, {{ell2edwards}}
@@ -2554,7 +2554,7 @@ This section defines ciphersuites for curve448 and edwards448 {{RFC7748}}.
 The suites curve448-SHA512-ELL2-RO- and curve448-SHA512-ELL2-NU-
 share the following parameters, in addition to the common parameters below.
 
-- E: B * y^2 = x^3 + A * x^2 + x, where
+- E: B * t^2 = s^3 + A * s^2 + s, where
   - A = 156326
   - B = 1
 - f: Elligator 2 method, {{elligator2}}
@@ -2562,7 +2562,7 @@ share the following parameters, in addition to the common parameters below.
 The suites edwards448-SHA512-EDELL2-RO- and edwards448-SHA512-EDELL2-NU-
 share the following parameters, in addition to the common parameters below.
 
-- E: a * x^2 + y^2 = 1 + d * x^2 * y^2, where
+- E: a * v^2 + w^2 = 1 + d * v^2 * w^2, where
   - a = 1
   - d = -39081
 - f: Twisted Edwards Elligator 2 method, {{ell2edwards}}
@@ -2888,6 +2888,7 @@ This mapping can be used to apply the Shallue-van de Woestijne method
 
 The rational map from the point (s, t) on the Montgomery curve
 B' * t^2 = s^3 + A' * s^2 + s
+over a field F = GF(p^m), p > 3,
 to the point (x, y) on the equivalent Weierstrass curve
 y^2 = x^3 + C * x + D
 is given by:

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -3552,20 +3552,21 @@ def find_z_ell2(F):
 # sqrt functions {#appx-sqrt}
 
 This section defines special-purpose sqrt functions for the three most common cases,
-p = 3 (mod 4), p = 5 (mod 8), and p = 9 (mod 16).
+q = 3 (mod 4), q = 5 (mod 8), and q = 9 (mod 16).
 In addition, it gives a generic constant-time algorithm that works for any prime modulus.
 
-## p = 3 (mod 4) {#sqrt-3mod4}
+{{AR13}} and {{S85}} describe optimized methods for extension fields.
+
+## q = 3 (mod 4) {#sqrt-3mod4}
 
 ~~~
 sqrt_3mod4(x)
 
 Parameters:
 - F, a finite field of characteristic p and order q = p^m.
-- p, the characteristic of F (see immediately above).
 
 Input: x, an element of F.
-Output: s, an element of F such that (s^2) == x.
+Output: z, an element of F such that (z^2) == x, if x is square in F.
 
 Constants:
 1. c1 = (q + 1) / 4     // Integer arithmetic
@@ -3574,17 +3575,16 @@ Procedure:
 1. return x^c1
 ~~~
 
-## p = 5 (mod 8) {#sqrt-5mod8}
+## q = 5 (mod 8) {#sqrt-5mod8}
 
 ~~~
 sqrt_5mod8(x)
 
 Parameters:
 - F, a finite field of characteristic p and order q = p^m.
-- p, the characteristic of F (see immediately above).
 
 Input: x, an element of F.
-Output: s, an element of F such that (s^2) == x.
+Output: z, an element of F such that (z^2) == x, if x is square in F.
 
 Constants:
 1. c1 = sqrt(-1) in F, i.e., (c1^2) == -1 in F
@@ -3593,24 +3593,20 @@ Constants:
 Procedure:
 1. t1 = x^c2
 2.  e = (t1^2) == x
-3.  s = CMOV(t1 * c1, t1, e)
-3. return s
+3.  z = CMOV(t1 * c1, t1, e)
+3. return z
 ~~~
 
-## p = 9 (mod 16) {#sqrt-9mod16}
-
-Note that this case also applies to GF(p^2) when p = 3 (mod 8).
-{{AR13}} and {{S85}} describe methods that work for other finite fields.
+## q = 9 (mod 16) {#sqrt-9mod16}
 
 ~~~
 sqrt_9mod16(x)
 
 Parameters:
 - F, a finite field of characteristic p and order q = p^m.
-- p, the characteristic of F (see immediately above).
 
 Input: x, an element of F.
-Output: s, an element of F such that (s^2) == x.
+Output: z, an element of F such that (z^2) == x, if x is square in F.
 
 Constants:
 1. c1 = sqrt(-1) in F, i.e., (c1^2) == -1 in F
@@ -3628,8 +3624,8 @@ Procedure:
 7.  t1 = CMOV(t1, t2, e1)  // Select t2 if (t2^2) == x
 8.  t2 = CMOV(t4, t3, e2)  // Select t3 if (t3^2) == x
 9.  e3 = (t2^2) == x
-10.  s = CMOV(t1, t2, e3)  // Select the sqrt from t1 and t2
-11. return s
+10.  z = CMOV(t1, t2, e3)  // Select the sqrt from t1 and t2
+11. return z
 ~~~
 
 ## Constant-time Tonelli-Shanks algorithm {#sqrt-ts}
@@ -3646,53 +3642,30 @@ faster, when they apply.
 sqrt_ts_ct(x)
 
 Parameters:
-- F, a finite field of order p
-- p, the characteristic of F (see immediately above)
+- F, a finite field of characteristic p and order q = p^m.
 
 Input x, an element of F.
-Output: s, an element of F such that s^2 == x, if x is a square in F.
+Output: z, an element of F such that z^2 == x, if x is square in F.
 
-Constants (see discussion below):
-1. c1, the largest integer such that 2^c1 divides p - 1.
-2. c2 = (p - 1) / (2^c1)        // Integer arithmetic
+Constants:
+1. c1, the largest integer such that 2^c1 divides q - 1.
+2. c2 = (q - 1) / (2^c1)        // Integer arithmetic
 3. c3 = (c2 - 1) / 2            // Integer arithmetic
 4. c4, a non-square value in F
 5. c5 = c4^c2 in F
 
 Procedure:
-1.  s = x^c3
-2.  t = s * s * x
-3.  s = s * x
+1.  z = x^c3
+2.  t = z * z * x
+3.  z = z * x
 4.  b = t
 5.  c = c5
 6.  for i in (c1, c1 - 1, ..., 2):
 7.      for j in (1, 2, ..., i - 2):
 8.           b = b * b
-9.      s = CMOV(s, s * c, b != 1)
+9.      z = CMOV(z, z * c, b != 1)
 10.     c = c * c
 11.     t = CMOV(t, t * c, b != 1)
 12.     b = t
-13. return s
-~~~
-
-The constants used in this procedure can be computed as follows:
-
-~~~
-precompute_ts(p)
-
-Input: p, a prime
-Output: the required constants c1, ..., c5
-
-Procedure:
-1.  c1 = 0
-2.  c2 = p - 1
-3.  while c2 is even:
-4.      c2 = c2 / 2             // Integer arithmetic
-5.      c1 = c1 + 1
-6.  c3 = (c2 - 1) / 2           // Integer arithmetic
-7.  c4 = 1
-8.  while c4 is square mod p:
-9.      c4 = c4 + 1
-10. c5 = c4^c2 mod p
-11. return (c1, c2, c3, c4, c5)
+13. return z
 ~~~

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -994,8 +994,8 @@ in a primitive element or polynomial basis, i.e., as a vector
 of m elements of GF(p) written in ascending order by degree.
 The entries of this vector are indexed in ascending order starting from 1,
 i.e., x = (x\_1, x\_2, ..., x\_m).
-For example, if q = p^2 and the primitive element basis is (1, i),
-then x = (a, b) corresponds to the element a + b * i, where
+For example, if q = p^2 and the primitive element basis is (1, I),
+then x = (a, b) corresponds to the element a + b * I, where
 x\_1 = a and x\_2 = b.
 
 An elliptic curve E is specified by an equation in two variables and a

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -3461,6 +3461,9 @@ This section gives Sage {{SAGE}} scripts used to generate parameters for the map
 The below function outputs an appropriate Z for the Shallue and van de Woestijne map ({{svdw}}).
 
 ~~~sage
+# Arguments:
+# - F, a field object, e.g., F = GF(2^521 - 1)
+# - A and B, the coefficients of the curve equation y^2 = x^3 + A * x + B
 def find_z_svdw(F, A, B):
     g = lambda x: F(x)^3 + F(A) * F(x) + F(B)
     h = lambda Z: -(F(3) * Z^2 + F(4) * A) / (F(4) * g(Z))

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2147,8 +2147,8 @@ Rational maps may be undefined on certain inputs, e.g., when the
 denominator of one of the rational functions is zero.
 In the map described above, the exceptional cases are Y == 0 or invSqrtD * X == -1.
 Implementations MUST detect exceptional cases and return the value
-(v, w) = (0, 1), which is a valid point (in fact, the identity point {{BBJLP08}})
-on all twisted Edwards curves given by the equation above.
+(v, w) = (0, 1), which is the identity point 
+on all twisted Edwards curves.
 
 The following straight-line implementation of the above rational map
 handles the exceptional cases.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1125,24 +1125,24 @@ under the assumption that random oracles answer only queries generated
 by that protocol.
 In practice, this assumption does not hold if two protocols query the
 same random oracle.
-Concretely, consider protocols P1 and P2 that query random oracle R:
-if P1 and P2 both query R on the same value x, the security analysis of
+Concretely, consider protocols P1 and P2 that query random oracle RO:
+if P1 and P2 both query RO on the same value x, the security analysis of
 one or both protocols may be invalidated.
 
 A common approach to addressing this issue is called domain separation,
 which allows a single random oracle to simulate multiple, independent oracles.
 This is effected by ensuring that each simulated oracle sees queries that are
 distinct from those seen by all other simulated oracles.
-For example, to simulate two oracles R1 and R2 given a single oracle R,
+For example, to simulate two oracles RO1 and RO2 given a single oracle RO,
 one might define
 
-    R1(x) := R("R1" || x)
-    R2(x) := R("R2" || x)
+    RO1(x) := RO("RO1" || x)
+    RO2(x) := RO("RO2" || x)
 
-In this example, "R1" and "R2" are called domain separation tags;
-they ensure that queries to R1 and R2 cannot result in identical
-queries to R.
-Thus, it is safe to treat R1 and R2 as independent oracles.
+In this example, "RO1" and "RO2" are called domain separation tags;
+they ensure that queries to RO1 and RO2 cannot result in identical
+queries to RO.
+Thus, it is safe to treat RO1 and RO2 as independent oracles.
 
 # Roadmap {#roadmap}
 
@@ -3620,8 +3620,8 @@ Procedure:
 3.  s = s * x
 4.  b = t
 5.  c = c5
-6.  for k in (c1, c1 - 1, ..., 2):
-7.      for j in (1, 2, ..., k - 2):
+6.  for i in (c1, c1 - 1, ..., 2):
+7.      for j in (1, 2, ..., i - 2):
 8.           b = b * b
 9.      s = CMOV(s, s * c, b != 1)
 10.     c = c * c

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1729,20 +1729,21 @@ to invert this product are exception free.
 Operations:
 
 ~~~
-1. t1 = u^2 * g(Z)
-2. t2 = 1 + t1
-3. t1 = 1 - t1
-4. t3 = inv0(t1 * t2)
-5. t4 = u * t1 * t3 * sqrt(-g(Z) * (3 * Z^2 + 4 * A))
-6. x1 = -Z / 2 - t4
-7. x2 = -Z / 2 + t4
-8. t5 = 2 * t2^2 * t3 * sqrt(-g(Z) / (3 * Z^2 + 4 * A))
-9. x3 = Z + t5^2
-10. If is_square(g(x1)), set x = x1 and y = sqrt(g(x1))
-11. Else If is_square(g(x2)), set x = x2 and y = sqrt(g(x2))
-12. Else set x = x3 and y = sqrt(g(x3))
-13. If sgn0(u) != sgn0(y), set y = -y
-14. return (x, y)
+1.  t1 = u^2 * g(Z)
+2.  t2 = 1 + t1
+3.  t1 = 1 - t1
+4.  t3 = inv0(t1 * t2)
+5.  t4 = sqrt(-g(Z) * (3 * Z^2 + 4 * A))
+6.  t4 = t4 * sgn0(t4)                          // sgn0(t4) MUST equal 1
+7.  t5 = u * t1 * t3 * t4
+8.  x1 = -Z / 2 - t5
+9.  x2 = -Z / 2 + t5
+10. x3 = Z - 4 * g(Z) * (t2^2 * t3)^2 / (3 * Z^2 + 4 * A)
+11. If is_square(g(x1)), set x = x1 and y = sqrt(g(x1))
+12. Else If is_square(g(x2)), set x = x2 and y = sqrt(g(x2))
+13. Else set x = x3 and y = sqrt(g(x3))
+14. If sgn0(u) != sgn0(y), set y = -y
+15. return (x, y)
 ~~~
 
 #### Implementation

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1304,9 +1304,6 @@ is_square(x) := { True,  if x^((q - 1) / 2) is 0 or 1 in F;
     Throughout the document, sgn0 is used generically to mean either of these variants.
     Each suite in {{suites}} specifies the sgn0 variant to be used.
 
--   abs(x): The absolute value of x is defined in terms of sgn0
-    in the natural way, namely, abs(x) := sgn0(x) * x.
-
 -   inv0(x): This function returns the multiplicative inverse of x in F,
     extended to all of F by fixing inv0(0) == 0.
     To implement inv0 in constant time, compute inv0(x) := x^(q - 2).
@@ -1617,7 +1614,7 @@ expensive than the curve-specific recommendations above.
 The generic interface shared by all mappings in this section is as follows:
 
 ~~~
-(x, y) = map_to_curve(u)
+    (x, y) = map_to_curve(u)
 ~~~
 
 The input u and outputs x and y are elements of the field F.
@@ -1674,7 +1671,12 @@ cases that result from attempting to compute the inverse of 0.
 ## Mappings for Weierstrass curves {#weierstrass}
 
 The following mappings apply to elliptic curves defined by the equation
-E: y^2 = g(x) = x^3 + A * x + B, where 4 * A^3 + 27 * B^2 != 0.
+
+~~~
+    y^2 = g(x) = x^3 + A * x + B
+~~~
+
+where 4 * A^3 + 27 * B^2 != 0.
 
 ### Shallue-van de Woestijne Method {#svdw}
 
@@ -1886,10 +1888,10 @@ Weierstrass curves having A == 0 or B == 0, which the mapping of
 This method applies to curves like secp256k1 {{SEC2}} and to pairing-friendly
 curves in the Barreto-Lynn-Scott {{BLS03}}, Barreto-Naehrig {{BN05}}, and other families.
 
-This method requires finding another elliptic curve
+This method requires finding another elliptic curve E' given by the equation
 
 ~~~
-E': y^2 = g'(x) = x^3 + A' * x + B'
+    y'^2 = g'(x') = x'^3 + A' * x' + B'
 ~~~
 
 that is isogenous to E and has A' != 0 and B' != 0.
@@ -1909,7 +1911,7 @@ the resulting points on E', and then applying iso\_map to the sum.
 This gives the same result while requiring only one evaluation of iso\_map.
 
 Preconditions: An elliptic curve E' with A' != 0 and B' != 0 that is
-isogenous to the target curve E with isogeny map iso\_map(x, y) from
+isogenous to the target curve E with isogeny map iso\_map from
 E' to E.
 
 Helper functions:
@@ -1936,10 +1938,20 @@ See {{hash2curve-repo}} or {{WB19}}, Section 4.3 for details on implementing the
 ## Mappings for Montgomery curves {#montgomery}
 
 The mapping defined in {{elligator2}} implements Elligator 2 {{BHKL13}} for
-curves defined by the Weierstrass equation y^2 = x^3 + A * x^2 + B * x.
+curves defined by the Weierstrass equation
 
-Such a Weierstrass curve is related to the Montgomery curve
-B' * t^2 = s^3 + A' * s^2 + s by the following change of variables:
+~~~
+    y^2 = x^3 + A * x^2 + B * x
+~~~
+
+(Note that this equation is different from the one used in {{weierstrass}}.)
+This Weierstrass curve is related to the Montgomery curve
+
+~~~
+    B' * t^2 = s^3 + A' * s^2 + s
+~~~
+
+by the following change of variables:
 
 - A = A' / B'
 - B = 1 / B'^2
@@ -2029,13 +2041,18 @@ Steps:
 
 Twisted Edwards curves (a class of curves that includes Edwards curves)
 are given by the equation
-a * v^2 + w^2 = 1 + d * v^2 * w^2, with a != 0, d != 0, and a != d {{BBJLP08}}.
+
+~~~
+    a * v^2 + w^2 = 1 + d * v^2 * w^2
+~~~
+
+with a != 0, d != 0, and a != d {{BBJLP08}}.
 
 These curves are closely related to Montgomery
 curves ({{montgomery}}): every twisted Edwards curve is birationally equivalent
 to a Montgomery curve ({{BBJLP08}}, Theorem 3.2).
 This equivalence yields an efficient way of hashing to a twisted Edwards curve:
-first, hash to the equivalent Montgomery curve, then transform the
+first, hash to an equivalent Montgomery curve, then transform the
 result into a point on the twisted Edwards curve via a rational map.
 This method of hashing to a twisted Edwards curve thus requires identifying a
 corresponding Montgomery curve and rational map.
@@ -2162,12 +2179,17 @@ Output: (v, w), a point on E.
 ### Boneh-Franklin Method {#bfmap}
 
 The function map\_to\_curve\_bf(u) implements the Boneh-Franklin method {{BF01}} which
-covers the supersingular curves defined by y^2 = x^3 + B over a field F such
-that q = 2 (mod 3).
+covers the supersingular curves defined by
 
-Preconditions: A supersingular curve over F such that q = 2 (mod 3).
+~~~
+    y^2 = x^3 + B
+~~~
 
-Constants: B, the parameter of the supersingular curve.
+over a field F = GF(q), q = 2 (mod 3).
+
+Preconditions: A curve whose equation and base field meet the requirements immediately above.
+
+Constants: B, the parameter of the curve.
 
 Sign of y: determined by sign of u. No adjustments are necessary.
 
@@ -2176,9 +2198,9 @@ Exceptions: none.
 Operations:
 
 ~~~
-1. w = (2 * q - 1) / 3    // Integer arithmetic
-2. x = (u^2 - B)^w
-3. y = u
+1. t1 = (2 * q - 1) / 3   // Integer arithmetic
+2.  x = (u^2 - B)^t1
+3.  y = u
 4. return (x, y)
 ~~~
 
@@ -2206,9 +2228,15 @@ Steps:
 ### Elligator 2, A == 0 Method {#ell2a0}
 
 The function map\_to\_curve\_ell2A0(u) implements an adaptation of Elligator 2
-{{BLMP19}} targeting curves given by y^2 = x^3 + B * x over F such that q = 3 (mod 4).
+{{BLMP19}} targeting curves given by
 
-Preconditions: An elliptic curve over F such that q = 3 (mod 4).
+~~~
+    y^2 = x^3 + B * x
+~~~
+
+over F = GF(q), q = 3 (mod 4).
+
+Preconditions: A curve whose equation and base field meet the requirements immediately above.
 
 Constants: B, the parameter of the elliptic curve.
 
@@ -2291,7 +2319,7 @@ The clear\_cofactor function is parameterized by a scalar h\_eff.
 Specifically,
 
 ~~~
-clear_cofactor(P) := h_eff * P
+    clear_cofactor(P) := h_eff * P
 ~~~
 
 where \* represents scalar multiplication.
@@ -2848,9 +2876,17 @@ This section gives several useful rational maps.
 
 The inverse of the rational map specified in {{rational-map}}, i.e.,
 the map from the point (v, w) on the twisted Edwards curve
-a * v^2 + w^2 = 1 + d * v^2 * w^2
+
+~~~
+    a * v^2 + w^2 = 1 + d * v^2 * w^2
+~~~
+
 to the point (x, y) on the Weierstrass curve
-y^2 = x^3 + A * x^2 + B * x
+
+~~~
+    y^2 = x^3 + A * x^2 + B * x
+~~~
+
 is given by:
 
 - A = (a + d) / 2
@@ -2859,11 +2895,18 @@ is given by:
 - x = (1 + w) / (B' * (1 - w))
 - y = (1 + w) / (B' * v * (1 - w))
 
-This map is undefined when w == 1 or v == 0.
-In this case, return the point (x, y) = (0, 0).
+This map is undefined when v == 0 or w == 1.
+If (v, w) = (0, -1), return the point (x, y) = (0, 0).
+Otherwise, return the identity point on the Weierstrass curve.
+(This follows from {{BBJLP08}}, Section 3.)
 
 It may also be useful to map to a Montgomery curve
-of the form B' * t^2 = s^3 + A' * s^2 + s.
+of the form
+
+~~~
+    B' * t^2 = s^3 + A' * s^2 + s
+~~~
+
 This curve is equivalent to the twisted Edwards curve above via the
 following rational map ({{BBJLP08}}, Theorem 3.2):
 
@@ -2887,10 +2930,18 @@ This mapping can be used to apply the Shallue-van de Woestijne method
 ## Montgomery to Weierstrass curves {#appx-rational-map-mont}
 
 The rational map from the point (s, t) on the Montgomery curve
-B' * t^2 = s^3 + A' * s^2 + s
+
+~~~
+    B' * t^2 = s^3 + A' * s^2 + s
+~~~
+
 over a field F = GF(p^m), p > 3,
 to the point (x, y) on the equivalent Weierstrass curve
-y^2 = x^3 + C * x + D
+
+~~~
+    y^2 = x^3 + C * x + D
+~~~
+
 is given by:
 
 - C = (3 - A'^2) / (3 * B'^2)
@@ -3089,7 +3140,7 @@ Specifically, each mapping function in this section has the following
 signature:
 
 ~~~
-(xn, xd, yn, nd) = map_to_curve(u)
+    (xn, xd, yn, nd) = map_to_curve(u)
 ~~~
 
 The resulting point (x, y) is given by (xn / xd, yn / yd).

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2310,7 +2310,7 @@ Input: u, an element of F.
 Output: (x, y), a point on E.
 
 Constants:
-1. c1 = (p + 1) / 4         # Integer arithmetic
+1. c1 = (q + 1) / 4         # Integer arithmetic
 
 Steps:
 1.  x1 = u

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2958,6 +2958,8 @@ following rational map ({{BBJLP08}}, Theorem 3.2):
 
 whose inverse is given by:
 
+- a = (J + 2) / K
+- d = (J - 2) / K
 - v = V / W
 - w = (V - 1) / (V + 1)
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1971,23 +1971,23 @@ curves defined by the Weierstrass equation
 This Weierstrass curve is equivalent to the Montgomery curve
 
 ~~~
-    K * W^2 = V^3 + J * V^2 + V
+    K * t^2 = s^3 + J * s^2 + s
 ~~~
 
 by the following change of variables:
 
 - C = J / K
 - D = 1 / K^2
-- X = V / K
-- Y = W / K
+- X = s / K
+- Y = t / K
 
 The Elligator 2 mapping given below returns a point (X, Y) on the
 Weierstrass curve defined above.
-This point can be converted to a point (V, W) on the equivalent
+This point can be converted to a point (s, t) on the equivalent
 Montgomery curve by computing
 
-- V = K * X
-- W = K * Y
+- s = K * X
+- t = K * Y
 
 Note that when D == K == 1, the above two curve equations
 are identical and no conversion is necessary.
@@ -2272,7 +2272,7 @@ over F = GF(q), q = 3 (mod 4).
 This method also works for curves given by the Montgomery equation
 
 ~~~
-    K * W^2 = V^3 + V
+    K * t^2 = s^3 + s
 ~~~
 
 via the change of variables given in {{montgomery}}.
@@ -2588,7 +2588,7 @@ This section defines ciphersuites for curve25519 and edwards25519 {{RFC7748}}.
 The suites curve25519-SHA256-ELL2-RO- and curve25519-SHA256-ELL2-NU-
 share the following parameters, in addition to the common parameters below.
 
-- E: K * W^2 = V^3 + J * V^2 + V, where
+- E: K * t^2 = s^3 + J * s^2 + s, where
   - J = 486662
   - K = 1
 - f: Elligator 2 method, {{elligator2}}
@@ -2623,7 +2623,7 @@ This section defines ciphersuites for curve448 and edwards448 {{RFC7748}}.
 The suites curve448-SHA512-ELL2-RO- and curve448-SHA512-ELL2-NU-
 share the following parameters, in addition to the common parameters below.
 
-- E: K * W^2 = V^3 + J * V^2 + V, where
+- E: K * t^2 = s^3 + J * s^2 + s, where
   - J = 156326
   - K = 1
 - f: Elligator 2 method, {{elligator2}}
@@ -2945,7 +2945,7 @@ It may also be useful to map to a Montgomery curve
 of the form
 
 ~~~
-    K * W^2 = V^3 + J * V^2 + V
+    K * t^2 = s^3 + J * s^2 + s
 ~~~
 
 This curve is equivalent to the twisted Edwards curve above via the
@@ -2953,15 +2953,15 @@ following rational map ({{BBJLP08}}, Theorem 3.2):
 
 - J = 2 * (a + d) / (a - d)
 - K = 4 / (a - d)
-- V = (1 + w) / (1 - w)
-- W = (1 + w) / (v * (1 - w))
+- s = (1 + w) / (1 - w)
+- t = (1 + w) / (v * (1 - w))
 
 whose inverse is given by:
 
 - a = (J + 2) / K
 - d = (J - 2) / K
-- v = V / W
-- w = (V - 1) / (V + 1)
+- v = s / t
+- w = (s - 1) / (s + 1)
 
 Composing the mapping immediately above with the mapping from
 Montgomery to Weierstrass curves in {{appx-rational-map-mont}}
@@ -2972,10 +2972,10 @@ This mapping can be used to apply the Shallue-van de Woestijne method
 
 ## Montgomery to Weierstrass curves {#appx-rational-map-mont}
 
-The rational map from the point (V, W) on the Montgomery curve
+The rational map from the point (s, t) on the Montgomery curve
 
 ~~~
-    K * W^2 = V^3 + J * V^2 + V
+    K * t^2 = s^3 + J * s^2 + s
 ~~~
 
 to the point (x, y) on the equivalent Weierstrass curve
@@ -2988,13 +2988,13 @@ is given by:
 
 - A = (3 - J^2) / (3 * K^2)
 - B = (2 * J^3 - 9 * J) / (27 * K^3)
-- x = (3 * V + J) / (3 * K)
-- y = W / K
+- x = (3 * s + J) / (3 * K)
+- y = t / K
 
-The inverse map, from the point (x, y) to the point (V, W), is given by
+The inverse map, from the point (x, y) to the point (s, t), is given by
 
-- V = (3 * K * x - J) / 3
-- W = y * K
+- s = (3 * K * x - J) / 3
+- t = y * K
 
 This mapping can be used to apply the Shallue-van de Woestijne method
 ({{svdw}}) to Montgomery curves.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -55,27 +55,15 @@ normative:
   RFC8017:
   RFC7748:
 informative:
-  draft-yonezawa-pfc-01:
-    title: Pairing-friendly Curves
-    target: https://datatracker.ietf.org/doc/draft-yonezawa-pairing-friendly-curves/
-    date: March 11, 2019
+  BLS12-381:
+    target: https://electriccoin.co/blog/new-snark-curve/
+    title: "BLS12-381: New zk-SNARK Elliptic Curve Construction"
+    date: Mar, 2017
     author:
       -
-        ins: S. Yonezawa
-        name: Shoko Yonezawa
-        org: Lepidum
-      -
-        ins: S. Chikara
-        name: Sakae Chikara
-        org: NTT TechnoCross
-      -
-        ins: T. Kobayashi
-        name: Tetsutaro Kobayashi
-        org: NTT
-      -
-        ins: T. Saito
-        name: Tsunekazu Saito
-        org: NTT
+        ins: S. Bowe
+        name: Sean Bowe
+        org: Electric Coin Company
   SEC1:
     title: "SEC 1: Elliptic Curve Cryptography"
     target: http://www.secg.org/sec1-v2.pdf
@@ -2630,7 +2618,7 @@ to the curve E' isogenous to secp256k1 is given in {{sswu-map-to-3mod4}}.
 ## Suites for BLS12-381 {#suites-bls12381}
 
 This section defines ciphersuites for groups G1 and G2 of
-the BLS12-381 elliptic curve {{draft-yonezawa-pfc-01}}.
+the BLS12-381 elliptic curve {{BLS12-381}}.
 
 ### BLS12-381 G1 {#suites-bls12381-g1}
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1549,8 +1549,8 @@ Steps:
 2. info_pfx = "H2C" || I2OSP(ctr, 1)   // "H2C" is a 3-byte ASCII string
 3. for i in (1, ..., m):
 4.   info = info_pfx || I2OSP(i, 1)
-5.   t = HKDF-Expand(msg_prime, info, L)
-6.   e_i = OS2IP(t) mod p
+5.   tv = HKDF-Expand(msg_prime, info, L)
+6.   e_i = OS2IP(tv) mod p
 7. u = (e_1, ..., e_m)
 8. return u
 ~~~
@@ -1663,9 +1663,9 @@ As a rough guide, the following conventions are used in pseudocode:
 - (x, y): the affine coordinates of the point output by the mapping.
   Indexed variables (e.g., x1, y2, ...) are used for candidate values.
 
-- t1, t2, ...: are reusable temporary variables.
+- tv1, tv2, ...: reusable temporary variables.
 
-- c1, c2, ...: are constant values, which can be computed in advance.
+- c1, c2, ...: constant values, which can be computed in advance.
 
 
 ## Sign of the resulting point {#point-sign}
@@ -1743,16 +1743,16 @@ to invert this product are exception free.
 Operations:
 
 ~~~
-1.  t1 = u^2 * g(Z)
-2.  t2 = 1 + t1
-3.  t1 = 1 - t1
-4.  t3 = inv0(t1 * t2)
-5.  t4 = sqrt(-g(Z) * (3 * Z^2 + 4 * A))
-6.  t4 = t4 * sgn0(t4)                          // sgn0(t4) MUST equal 1
-7.  t5 = u * t1 * t3 * t4
-8.  x1 = -Z / 2 - t5
-9.  x2 = -Z / 2 + t5
-10. x3 = Z - 4 * g(Z) * (t2^2 * t3)^2 / (3 * Z^2 + 4 * A)
+1. tv1 = u^2 * g(Z)
+2. tv2 = 1 + tv1
+3. tv1 = 1 - tv1
+4. tv3 = inv0(tv1 * tv2)
+5. tv4 = sqrt(-g(Z) * (3 * Z^2 + 4 * A))
+6. tv4 = tv4 * sgn0(tv4)                   // sgn0(tv4) MUST equal 1
+7. tv5 = u * tv1 * tv3 * tv4
+8.  x1 = -Z / 2 - tv5
+9.  x2 = -Z / 2 + tv5
+10. x3 = Z - 4 * g(Z) * (tv2^2 * tv3)^2 / (3 * Z^2 + 4 * A)
 11. If is_square(g(x1)), set x = x1 and y = sqrt(g(x1))
 12. Else If is_square(g(x2)), set x = x2 and y = sqrt(g(x2))
 13. Else set x = x3 and y = sqrt(g(x3))
@@ -1777,29 +1777,29 @@ Constants:
 4. c4 = -4 * g(Z) / (3 * Z^2 + 4 * A)
 
 Steps:
-1.   t1 = u^2
-2.   t1 = t1 * c1
-3.   t2 = 1 + t1
-4.   t1 = 1 - t1
-5.   t3 = t1 * t2
-6.   t3 = inv0(t3)
-7.   t4 = u * t1
-8.   t4 = t4 * t3
-9.   t4 = t4 * c3
-10.  x1 = c2 - t4
+1.  tv1 = u^2
+2.  tv1 = tv1 * c1
+3.  tv2 = 1 + tv1
+4.  tv1 = 1 - tv1
+5.  tv3 = tv1 * tv2
+6.  tv3 = inv0(tv3)
+7.  tv4 = u * tv1
+8.  tv4 = tv4 * tv3
+9.  tv4 = tv4 * c3
+10.  x1 = c2 - tv4
 11. gx1 = x1^2
 12. gx1 = gx1 + A
 13. gx1 = gx1 * x1
 14. gx1 = gx1 + B
 15.  e1 = is_square(gx1)
-16.  x2 = c2 + t4
+16.  x2 = c2 + tv4
 17. gx2 = x2^2
 18. gx2 = gx2 + A
 19. gx2 = gx2 * x2
 20. gx2 = gx2 + B
 21.  e2 = is_square(gx2) AND NOT e1     // Avoid short-circuit logic ops
-22.  x3 = t2^2
-23.  x3 = x3 * t3
+22.  x3 = tv2^2
+23.  x3 = x3 * tv3
 24.  x3 = x3^2
 25.  x3 = x3 * c4
 26.  x3 = x3 + Z
@@ -1848,9 +1848,9 @@ is square by the condition on Z given above.
 Operations:
 
 ~~~
-1.  t1 = inv0(Z^2 * u^4 + Z * u^2)
-2.  x1 = (-B / A) * (1 + t1)
-3.  If t1 == 0, set x1 = B / (Z * A)
+1. tv1 = inv0(Z^2 * u^4 + Z * u^2)
+2.  x1 = (-B / A) * (1 + tv1)
+3.  If tv1 == 0, set x1 = B / (Z * A)
 4. gx1 = x1^3 + A * x1 + B
 5.  x2 = Z * u^2 * x1
 6. gx2 = x2^3 + A * x2 + B
@@ -1877,21 +1877,21 @@ Constants:
 2.  c2 = -1 / Z
 
 Steps:
-1.   t1 = Z * u^2
-2.   t2 = t1^2
-3.   x1 = t1 + t2
+1.  tv1 = Z * u^2
+2.  tv2 = tv1^2
+3.   x1 = tv1 + tv2
 4.   x1 = inv0(x1)
 5.   e1 = x1 == 0
 6.   x1 = x1 + 1
-7.   x1 = CMOV(x1, c2, e1)    // If (t1 + t2) == 0, set x1 = -1 / Z
+7.   x1 = CMOV(x1, c2, e1)    // If (tv1 + tv2) == 0, set x1 = -1 / Z
 8.   x1 = x1 * c1      // x1 = (-B / A) * (1 + (1 / (Z^2 * u^4 + Z * u^2)))
 9.  gx1 = x1^2
 10. gx1 = gx1 + A
 11. gx1 = gx1 * x1
 12. gx1 = gx1 + B             // gx1 = g(x1) = x1^3 + A * x1 + B
-13.  x2 = t1 * x1             // x2 = Z * u^2 * x1
-14.  t2 = t1 * t2
-15. gx2 = gx1 * t2            // gx2 = (Z * u^2)^3 * gx1
+13.  x2 = tv1 * x1            // x2 = Z * u^2 * x1
+14. tv2 = tv1 * tv2
+15. gx2 = gx1 * tv2           // gx2 = (Z * u^2)^3 * gx1
 16.  e2 = is_square(gx1)
 17.   x = CMOV(x2, x1, e2)    // If is_square(gx1), x = x1, else x = x2
 18.  y2 = CMOV(gx2, gx1, e2)  // If is_square(gx1), y2 = gx1, else y2 = gx2
@@ -2038,11 +2038,11 @@ Input: u, an element of F.
 Output: (x, y), a point on E.
 
 Steps:
-1.   t1 = u^2
-2.   t1 = Z * t1              // Z * u^2
-3.   e1 = t1 == -1            // exceptional case: Z * u^2 == -1
-4.   t1 = CMOV(t1, 0, e1)     // if t1 == -1, set t1 = 0
-5.   x1 = t1 + 1
+1.  tv1 = u^2
+2.  tv1 = Z * tv1             // Z * u^2
+3.   e1 = tv1 == -1           // exceptional case: Z * u^2 == -1
+4.  tv1 = CMOV(tv1, 0, e1)    // if tv1 == -1, set tv1 = 0
+5.   x1 = tv1 + 1
 6.   x1 = inv0(x1)
 7.   x1 = -C * x1             // x1 = -C / (1 + Z * u^2)
 8.  gx1 = x1 + C
@@ -2050,7 +2050,7 @@ Steps:
 10. gx1 = gx1 + D
 11. gx1 = gx1 * x1            // gx1 = x1^3 + C * x1^2 + D * x1
 12.  x2 = -x1 - C
-13. gx2 = t1 * gx1
+13. gx2 = tv1 * gx1
 14.  e2 = is_square(gx1)
 15.   x = CMOV(x2, x1, e2)    // If is_square(gx1), x = x1, else x = x2
 16.  y2 = CMOV(gx2, gx1, e2)  // If is_square(gx1), y2 = gx1, else y2 = gx2
@@ -2160,17 +2160,17 @@ rational_map(x, y)
 Input: (x, y), a point on the curve Y^2 = X^3 + C * X^2 + D * X.
 Output: (v, w), a point on an equivalent twisted Edwards curve.
 
-1. t1 = x * invSqrtD
-2. t2 = t1 + 1
-3. t3 = y * t2
-4. t3 = inv0(t3)
-5.  v = t2 * t3
-6.  v = v * x
-7.  w = t1 - 1
-8.  w = w * y
-9.  w = w * t3
-10. e = w == 0
-11. w = CMOV(w, 1, e)
+1. tv1 = x * invSqrtD
+2. tv2 = tv1 + 1
+3. tv3 = y * tv2
+4. tv3 = inv0(tv3)
+5.   v = tv2 * tv3
+6.   v = v * x
+7.   w = tv1 - 1
+8.   w = w * y
+9.   w = w * tv3
+10.  e = w == 0
+11.  w = CMOV(w, 1, e)
 12. return (v, w)
 ~~~
 
@@ -2232,9 +2232,9 @@ Exceptions: none.
 Operations:
 
 ~~~
-1. t1 = (2 * q - 1) / 3   // Integer arithmetic
-2.  x = (u^2 - B)^t1
-3.  y = u
+1. tv1 = (2 * q - 1) / 3   // Integer arithmetic
+2.   x = (u^2 - B)^tv1
+3.   y = u
 4. return (x, y)
 ~~~
 
@@ -2252,10 +2252,10 @@ Constants:
 1. c1 = (2 * q - 1) / 3   // Integer arithmetic
 
 Steps:
-1. t1 = u^2
-2. t1 = t1 - B
-3.  x = t1^c1             // x = (u^2 - B)^((2 * q - 1) / 3)
-4.  y = u
+1. tv1 = u^2
+2. tv1 = tv1 - B
+3.   x = tv1^c1             // x = (u^2 - B)^((2 * q - 1) / 3)
+4.   y = u
 5. return (x, y)
 ~~~
 
@@ -3238,35 +3238,35 @@ Constants: defined per curve; see above.
 2.  c2 = sqrt(-Z^3)
 
 Steps:
-1.   t1 = u^2
-2.   t3 = Z * t1
-3.   t2 = t3^2
-4.   xd = t2 + t3
+1.  tv1 = u^2
+2.  tv3 = Z * tv1
+3.  tv2 = tv3^2
+4.   xd = tv2 + tv3
 5.  x1n = xd + 1
 6.  x1n = x1n * B
 7.   xd = -A * xd
 8.   e1 = xd == 0
 9.   xd = CMOV(xd, Z * A, e1)  // If xd == 0, set xd = Z * A
-10.  t2 = xd^2
-11. gxd = t2 * xd              // gxd == xd^3
-12.  t2 = A * t2
+10. tv2 = xd^2
+11. gxd = tv2 * xd             // gxd == xd^3
+12. tv2 = A * tv2
 13. gx1 = x1n^2
-14. gx1 = gx1 + t2             // x1n^2 + A * xd^2
+14. gx1 = gx1 + tv2            // x1n^2 + A * xd^2
 15. gx1 = gx1 * x1n            // x1n^3 + A * x1n * xd^2
-16.  t2 = B * gxd
-17. gx1 = gx1 + t2             // x1n^3 + A * x1n * xd^2 + B * xd^3
-18.  t4 = gxd^2
-19.  t2 = gx1 * gxd
-20.  t4 = t4 * t2              // gx1 * gxd^3
-21.  y1 = t4^c1                // (gx1 * gxd^3)^((p - 3) / 4)
-22.  y1 = y1 * t2              // gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
-23. x2n = t3 * x1n             // x2 = x2n / xd = -10 * u^2 * x1n / xd
+16. tv2 = B * gxd
+17. gx1 = gx1 + tv2            // x1n^3 + A * x1n * xd^2 + B * xd^3
+18. tv4 = gxd^2
+19. tv2 = gx1 * gxd
+20. tv4 = tv4 * tv2            // gx1 * gxd^3
+21.  y1 = tv4^c1               // (gx1 * gxd^3)^((p - 3) / 4)
+22.  y1 = y1 * tv2             // gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
+23. x2n = tv3 * x1n            // x2 = x2n / xd = -10 * u^2 * x1n / xd
 24.  y2 = y1 * c2              // y2 = y1 * sqrt(-Z^3)
-25.  y2 = y2 * t1
+25.  y2 = y2 * tv1
 26.  y2 = y2 * u
-27.  t2 = y1^2
-28.  t2 = t2 * gxd
-29.  e2 = t2 == gx1
+27. tv2 = y1^2
+28. tv2 = tv2 * gxd
+29.  e2 = tv2 == gx1
 30.  xn = CMOV(x2n, x1n, e2)   // If e2, x = x1, else x = x2
 31.   y = CMOV(y2, y1, e2)     // If e2, y = y1, else y = y2
 32.  e3 = sgn0(u) == sgn0(y)   // Fix sign of y
@@ -3293,41 +3293,41 @@ Constants:
 4. c4 = (p - 5) / 8           // Integer arithmetic
 
 Steps:
-1.   t1 = u^2
-2.   t1 = 2 * t1
-3.   xd = t1 + 1              // Nonzero: -1 is square (mod p), t1 is not
+1.  tv1 = u^2
+2.  tv1 = 2 * tv1
+3.   xd = tv1 + 1             // Nonzero: -1 is square (mod p), tv1 is not
 4.  x1n = -486662             // x1 = x1n / xd = -486662 / (1 + 2 * u^2)
-5.   t2 = xd^2
-6.  gxd = t2 * xd             // gxd = xd^3
+5.  tv2 = xd^2
+6.  gxd = tv2 * xd            // gxd = xd^3
 7.  gx1 = 486662 * xd         // 486662 * xd
 8.  gx1 = gx1 + x1n           // x1n + 486662 * xd
 9.  gx1 = gx1 * x1n           // x1n^2 + 486662 * x1n * xd
-10. gx1 = gx1 + t2            // x1n^2 + 486662 * x1n * xd + xd^2
+10. gx1 = gx1 + tv2           // x1n^2 + 486662 * x1n * xd + xd^2
 11. gx1 = gx1 * x1n           // x1n^3 + 486662 * x1n^2 * xd + x1n * xd^2
-12.  t3 = gxd^2
-13.  t2 = t3^2                // gxd^4
-14.  t3 = t3 * gxd            // gxd^3
-15.  t3 = t3 * gx1            // gx1 * gxd^3
-16.  t2 = t2 * t3             // gx1 * gxd^7
-17. y11 = t2^c4               // (gx1 * gxd^7)^((p - 5) / 8)
-18. y11 = y11 * t3            // gx1 * gxd^3 * (gx1 * gxd^7)^((p - 5) / 8)
+12. tv3 = gxd^2
+13. tv2 = tv3^2               // gxd^4
+14. tv3 = tv3 * gxd           // gxd^3
+15. tv3 = tv3 * gx1           // gx1 * gxd^3
+16. tv2 = tv2 * tv3           // gx1 * gxd^7
+17. y11 = tv2^c4              // (gx1 * gxd^7)^((p - 5) / 8)
+18. y11 = y11 * tv3           // gx1 * gxd^3 * (gx1 * gxd^7)^((p - 5) / 8)
 19. y12 = y11 * c3
-20.  t2 = y11^2
-21.  t2 = t2 * gxd
-22.  e1 = t2 == gx1
+20. tv2 = y11^2
+21. tv2 = tv2 * gxd
+22.  e1 = tv2 == gx1
 23.  y1 = CMOV(y12, y11, e1)  // If g(x1) is square, this is its sqrt
-24. x2n = x1n * t1            // x2 = x2n / xd = 2 * u^2 * x1n / xd
+24. x2n = x1n * tv1           // x2 = x2n / xd = 2 * u^2 * x1n / xd
 25. y21 = y11 * u
 26. y21 = y21 * c2
 27. y22 = y21 * c3
-28. gx2 = gx1 * t1            // g(x2) = gx2 / gxd = 2 * u^2 * g(x1)
-29.  t2 = y21^2
-30.  t2 = t2 * gxd
-31.  e2 = t2 == gx2
+28. gx2 = gx1 * tv1           // g(x2) = gx2 / gxd = 2 * u^2 * g(x1)
+29. tv2 = y21^2
+30. tv2 = tv2 * gxd
+31.  e2 = tv2 == gx2
 32.  y2 = CMOV(y22, y21, e2)  // If g(x2) is square, this is its sqrt
-33.  t2 = y1^2
-34.  t2 = t2 * gxd
-35.  e3 = t2 == gx1
+33. tv2 = y1^2
+34. tv2 = tv2 * gxd
+35.  e3 = tv2 == gx1
 36.  xn = CMOV(x2n, x1n, e3)  // If e3, x = x1, else x = x2
 37.   y = CMOV(y2, y1, e3)    // If e3, y = y1, else y = y2
 38.  e4 = sgn0(u) == sgn0(y)  // Fix sign of y
@@ -3359,8 +3359,8 @@ Steps:
 4.  xd = xMd * yMn       // xn / xd = c1 * xM / yM
 5.  yn = xMn - xMd
 6.  yd = xMn + xMd       // (n / d - 1) / (n / d + 1) = (n - d) / (n + d)
-7.  t1 = xd * yd
-8.   e = t1 == 0
+7. tv1 = xd * yd
+8.   e = tv1 == 0
 9.  xn = CMOV(xn, 0, e)
 10. xd = CMOV(xd, 1, e)
 11. yn = CMOV(yn, 1, e)
@@ -3384,29 +3384,29 @@ Constants:
 1. c1 = (p - 3) / 4           // Integer arithmetic
 
 Steps:
-1.   t1 = u^2
-2.   e1 = t1 == 1
-3.   t1 = CMOV(t1, 0, e1)     // If Z * u^2 == -1, set t1 = 0
-4.   xd = 1 - t1
+1.  tv1 = u^2
+2.   e1 = tv1 == 1
+3.  tv1 = CMOV(tv1, 0, e1)    // If Z * u^2 == -1, set tv1 = 0
+4.   xd = 1 - tv1
 5.  x1n = -156326
-6.   t2 = xd^2
-7.  gxd = t2 * xd             // gxd = xd^3
+6.  tv2 = xd^2
+7.  gxd = tv2 * xd            // gxd = xd^3
 8.  gx1 = 156326 * xd         // 156326 * xd
 9.  gx1 = gx1 + x1n           // x1n + 156326 * xd
 10. gx1 = gx1 * x1n           // x1n^2 + 156326 * x1n * xd
-11. gx1 = gx1 + t2            // x1n^2 + 156326 * x1n * xd + xd^2
+11. gx1 = gx1 + tv2           // x1n^2 + 156326 * x1n * xd + xd^2
 12. gx1 = gx1 * x1n           // x1n^3 + 156326 * x1n^2 * xd + x1n * xd^2
-13.  t3 = gxd^2
-14.  t2 = gx1 * gxd           // gx1 * gxd
-15.  t3 = t3 * t2             // gx1 * gxd^3
-16.  y1 = t3^c1               // (gx1 * gxd^3)^((p - 3) / 4)
-17.  y1 = y1 * t2             // gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
-18. x2n = -t1 * x1n           // x2 = x2n / xd = -1 * u^2 * x1n / xd
+13. tv3 = gxd^2
+14. tv2 = gx1 * gxd           // gx1 * gxd
+15. tv3 = tv3 * tv2           // gx1 * gxd^3
+16.  y1 = tv3^c1              // (gx1 * gxd^3)^((p - 3) / 4)
+17.  y1 = y1 * tv2            // gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
+18. x2n = -tv1 * x1n          // x2 = x2n / xd = -1 * u^2 * x1n / xd
 19.  y2 = y1 * u
 20.  y2 = CMOV(y2, 0, e1)
-21.  t2 = y1^2
-22.  t2 = t2 * gxd
-23.  e2 = t2 == gx1
+21. tv2 = y1^2
+22. tv2 = tv2 * gxd
+23.  e2 = tv2 == gx1
 24.  xn = CMOV(x2n, x1n, e2)  // If e2, x = x1, else x = x2
 25.   y = CMOV(y2, y1, e2)    // If e2, y = y1, else y = y2
 26.  e3 = sgn0(u) == sgn0(y)  // Fix sign of y
@@ -3436,32 +3436,32 @@ Steps:
 5.  yn2 = yn^2
 6.  yd2 = yd^2
 7.  xEn = xn2 - xd2
-8.   t2 = xEn - xd2
+8.  tv2 = xEn - xd2
 9.  xEn = xEn * xd2
 10. xEn = xEn * yd
 11. xEn = xEn * yn
 12. xEn = xEn * 4
-13.  t2 = t2 * xn2
-14.  t2 = t2 * yd2
-15.  t3 = 4 * yn2
-16.  t1 = t3 + yd2
-17.  t1 = t1 * xd4
-18. xEd = t1 + t2
-19.  t2 = t2 * xn
-20.  t4 = xn * xd4
-21. yEn = t3 - yd2
-22. yEn = yEn * t4
-23. yEn = yEn - t2
-24.  t1 = xn2 + xd2
-25.  t1 = t1 * xd2
-26.  t1 = t1 * xd
-27.  t1 = t1 * yn2
-28.  t1 = -2 * t1
-29. yEd = t2 + t1
-30.  t4 = t4 * yd2
-31. yEd = yEd + t4
-32.  t1 = xEd * yEd
-33.   e = t1 == 0
+13. tv2 = tv2 * xn2
+14. tv2 = tv2 * yd2
+15. tv3 = 4 * yn2
+16. tv1 = tv3 + yd2
+17. tv1 = tv1 * xd4
+18. xEd = tv1 + tv2
+19. tv2 = tv2 * xn
+20. tv4 = xn * xd4
+21. yEn = tv3 - yd2
+22. yEn = yEn * tv4
+23. yEn = yEn - tv2
+24. tv1 = xn2 + xd2
+25. tv1 = tv1 * xd2
+26. tv1 = tv1 * xd
+27. tv1 = tv1 * yn2
+28. tv1 = -2 * tv1
+29. yEd = tv2 + tv1
+30. tv4 = tv4 * yd2
+31. yEd = yEd + tv4
+32. tv1 = xEd * yEd
+33.   e = tv1 == 0
 34. xEn = CMOV(xEn, 0, e)
 35. xEd = CMOV(xEd, 1, e)
 36. yEn = CMOV(yEn, 1, e)
@@ -3591,9 +3591,9 @@ Constants:
 2. c2 = (q + 3) / 8     // Integer arithmetic
 
 Procedure:
-1. t1 = x^c2
-2.  e = (t1^2) == x
-3.  z = CMOV(t1 * c1, t1, e)
+1. tv1 = x^c2
+2.   e = (tv1^2) == x
+3.   z = CMOV(tv1 * c1, tv1, e)
 3. return z
 ~~~
 
@@ -3615,16 +3615,16 @@ Constants:
 4. c4 = (q + 7) / 16    // Integer arithmetic
 
 Procedure:
-1.  t1 = x^c4
-2.  t2 = c1 * t1
-3.  t3 = c2 * t1
-4.  t4 = c3 * t1
-5.  e1 = (t2^2) == x
-6.  e2 = (t3^2) == x
-7.  t1 = CMOV(t1, t2, e1)  // Select t2 if (t2^2) == x
-8.  t2 = CMOV(t4, t3, e2)  // Select t3 if (t3^2) == x
-9.  e3 = (t2^2) == x
-10.  z = CMOV(t1, t2, e3)  // Select the sqrt from t1 and t2
+1. tv1 = x^c4
+2. tv2 = c1 * tv1
+3. tv3 = c2 * tv1
+4. tv4 = c3 * tv1
+5.  e1 = (tv2^2) == x
+6.  e2 = (tv3^2) == x
+7. tv1 = CMOV(tv1, tv2, e1)  // Select tv2 if (tv2^2) == x
+8. tv2 = CMOV(tv4, tv3, e2)  // Select tv3 if (tv3^2) == x
+9.  e3 = (tv2^2) == x
+10.  z = CMOV(tv1, tv2, e3)  // Select the sqrt from tv1 and tv2
 11. return z
 ~~~
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1225,7 +1225,7 @@ Steps:
 2. u1 = hash_to_base(alpha, 1)
 3. Q0 = map_to_curve(u0)
 4. Q1 = map_to_curve(u1)
-5. R = Q0 + Q1 // Point addition
+5. R = Q0 + Q1              # Point addition
 6. P = clear_cofactor(R)
 7. return P
 ~~~
@@ -1397,7 +1397,7 @@ Steps:
 3.   sign_i = CMOV(1, -1, x_i > ((p - 1) / 2))
 4.   sign_i = CMOV(sign_i, 0, x_i == 0)
 5.   sign = CMOV(sign, sign_i, sign == 0)
-6. return CMOV(sign, 1, sign == 0)    // Regard x == 0 as positive
+6. return CMOV(sign, 1, sign == 0)      # Regard x == 0 as positive
 ~~~
 
 ### Little endian variant {#sgn0-le}
@@ -1435,7 +1435,7 @@ Steps:
 3.   sign_i = CMOV(1, -1, x_i mod 2 == 1)
 4.   sign_i = CMOV(sign_i, 0, x_i == 0)
 5.   sign = CMOV(sign, sign_i, sign == 0)
-6. return CMOV(sign, 1, sign == 0)     // regard x == 0 as positive
+6. return CMOV(sign, 1, sign == 0)      # Regard x == 0 as positive
 ~~~
 
 # Hashing to a Finite Field {#hashtobase}
@@ -1546,7 +1546,7 @@ Output:
 
 Steps:
 1. msg_prime = HKDF-Extract(DST, msg || I2OSP(0, 1))
-2. info_pfx = "H2C" || I2OSP(ctr, 1)   // "H2C" is a 3-byte ASCII string
+2. info_pfx = "H2C" || I2OSP(ctr, 1)   # "H2C" is a 3-byte ASCII string
 3. for i in (1, ..., m):
 4.   info = info_pfx || I2OSP(i, 1)
 5.   tv = HKDF-Expand(msg_prime, info, L)
@@ -1748,7 +1748,7 @@ Operations:
 3. tv1 = 1 - tv1
 4. tv3 = inv0(tv1 * tv2)
 5. tv4 = sqrt(-g(Z) * (3 * Z^2 + 4 * A))
-6. tv4 = tv4 * sgn0(tv4)                   // sgn0(tv4) MUST equal 1
+6. tv4 = tv4 * sgn0(tv4)                    # sgn0(tv4) MUST equal 1
 7. tv5 = u * tv1 * tv3 * tv4
 8.  x1 = -Z / 2 - tv5
 9.  x2 = -Z / 2 + tv5
@@ -1773,7 +1773,7 @@ Output: (x, y), a point on E.
 Constants:
 1. c1 = g(Z)
 2. c2 = -Z / 2
-3. c3 = sqrt(-g(Z) * (3 * Z^2 + 4 * A))         // sgn0(c3) MUST equal 1
+3. c3 = sqrt(-g(Z) * (3 * Z^2 + 4 * A))     # sgn0(c3) MUST equal 1
 4. c4 = -4 * g(Z) / (3 * Z^2 + 4 * A)
 
 Steps:
@@ -1797,21 +1797,21 @@ Steps:
 18. gx2 = gx2 + A
 19. gx2 = gx2 * x2
 20. gx2 = gx2 + B
-21.  e2 = is_square(gx2) AND NOT e1     // Avoid short-circuit logic ops
+21.  e2 = is_square(gx2) AND NOT e1     # Avoid short-circuit logic ops
 22.  x3 = tv2^2
 23.  x3 = x3 * tv3
 24.  x3 = x3^2
 25.  x3 = x3 * c4
 26.  x3 = x3 + Z
-27.   x = CMOV(x3, x1, e1)      // x = x1 if gx1 is square, else x = x3
-28.   x = CMOV(x, x2, e2)       // x = x2 if gx2 is square and gx1 is not
+27.   x = CMOV(x3, x1, e1)      # x = x1 if gx1 is square, else x = x3
+28.   x = CMOV(x, x2, e2)       # x = x2 if gx2 is square and gx1 is not
 29.  gx = x^2
 30.  gx = gx + A
 31.  gx = gx * x
 32.  gx = gx + B
 33.   y = sqrt(gx)
 34.  e3 = sgn0(u) == sgn0(y)
-35.   y = CMOV(-y, y, e3)       // Select correct sign of y
+35.   y = CMOV(-y, y, e3)       # Select correct sign of y
 36. return (x, y)
 ~~~
 
@@ -1883,20 +1883,20 @@ Steps:
 4.   x1 = inv0(x1)
 5.   e1 = x1 == 0
 6.   x1 = x1 + 1
-7.   x1 = CMOV(x1, c2, e1)    // If (tv1 + tv2) == 0, set x1 = -1 / Z
-8.   x1 = x1 * c1      // x1 = (-B / A) * (1 + (1 / (Z^2 * u^4 + Z * u^2)))
+7.   x1 = CMOV(x1, c2, e1)    # If (tv1 + tv2) == 0, set x1 = -1 / Z
+8.   x1 = x1 * c1      # x1 = (-B / A) * (1 + (1 / (Z^2 * u^4 + Z * u^2)))
 9.  gx1 = x1^2
 10. gx1 = gx1 + A
 11. gx1 = gx1 * x1
-12. gx1 = gx1 + B             // gx1 = g(x1) = x1^3 + A * x1 + B
-13.  x2 = tv1 * x1            // x2 = Z * u^2 * x1
+12. gx1 = gx1 + B             # gx1 = g(x1) = x1^3 + A * x1 + B
+13.  x2 = tv1 * x1            # x2 = Z * u^2 * x1
 14. tv2 = tv1 * tv2
-15. gx2 = gx1 * tv2           // gx2 = (Z * u^2)^3 * gx1
+15. gx2 = gx1 * tv2           # gx2 = (Z * u^2)^3 * gx1
 16.  e2 = is_square(gx1)
-17.   x = CMOV(x2, x1, e2)    // If is_square(gx1), x = x1, else x = x2
-18.  y2 = CMOV(gx2, gx1, e2)  // If is_square(gx1), y2 = gx1, else y2 = gx2
+17.   x = CMOV(x2, x1, e2)    # If is_square(gx1), x = x1, else x = x2
+18.  y2 = CMOV(gx2, gx1, e2)  # If is_square(gx1), y2 = gx1, else y2 = gx2
 19.   y = sqrt(y2)
-20.  e3 = sgn0(u) == sgn0(y)  // Fix sign of y
+20.  e3 = sgn0(u) == sgn0(y)  # Fix sign of y
 21.   y = CMOV(-y, y, e3)
 22. return (x, y)
 ~~~
@@ -1951,8 +1951,8 @@ Exceptional cases of iso\_map MUST return the identity point on E.
 Operations:
 
 ~~~
-1. (x', y') = map_to_curve_simple_swu(u)    // (x', y') is on E'
-2.   (x, y) = iso_map(x', y')               // (x, y) is on E
+1. (x', y') = map_to_curve_simple_swu(u)    # (x', y') is on E'
+2.   (x, y) = iso_map(x', y')               # (x, y) is on E
 3. return (x, y)
 ~~~
 
@@ -2039,23 +2039,23 @@ Output: (x, y), a point on E.
 
 Steps:
 1.  tv1 = u^2
-2.  tv1 = Z * tv1             // Z * u^2
-3.   e1 = tv1 == -1           // exceptional case: Z * u^2 == -1
-4.  tv1 = CMOV(tv1, 0, e1)    // if tv1 == -1, set tv1 = 0
+2.  tv1 = Z * tv1             # Z * u^2
+3.   e1 = tv1 == -1           # exceptional case: Z * u^2 == -1
+4.  tv1 = CMOV(tv1, 0, e1)    # if tv1 == -1, set tv1 = 0
 5.   x1 = tv1 + 1
 6.   x1 = inv0(x1)
-7.   x1 = -C * x1             // x1 = -C / (1 + Z * u^2)
+7.   x1 = -C * x1             # x1 = -C / (1 + Z * u^2)
 8.  gx1 = x1 + C
 9.  gx1 = gx1 * x1
 10. gx1 = gx1 + D
-11. gx1 = gx1 * x1            // gx1 = x1^3 + C * x1^2 + D * x1
+11. gx1 = gx1 * x1            # gx1 = x1^3 + C * x1^2 + D * x1
 12.  x2 = -x1 - C
 13. gx2 = tv1 * gx1
 14.  e2 = is_square(gx1)
-15.   x = CMOV(x2, x1, e2)    // If is_square(gx1), x = x1, else x = x2
-16.  y2 = CMOV(gx2, gx1, e2)  // If is_square(gx1), y2 = gx1, else y2 = gx2
+15.   x = CMOV(x2, x1, e2)    # If is_square(gx1), x = x1, else x = x2
+16.  y2 = CMOV(gx2, gx1, e2)  # If is_square(gx1), y2 = gx1, else y2 = gx2
 17.   y = sqrt(y2)
-18.  e3 = sgn0(u) == sgn0(y)  // Fix sign of y
+18.  e3 = sgn0(u) == sgn0(y)  # Fix sign of y
 19.   y = CMOV(-y, y, e3)
 20. return (x, y)
 ~~~
@@ -2203,8 +2203,8 @@ map_to_curve_elligator2_edwards(u)
 Input: u, an element of F.
 Output: (v, w), a point on E.
 
-1. (x, y) = map_to_curve_elligator2(u)      // (x, y) is on M
-2. (v, w) = rational_map(x, y)              // (v, w) is on E
+1. (x, y) = map_to_curve_elligator2(u)      # (x, y) is on M
+2. (v, w) = rational_map(x, y)              # (v, w) is on E
 3. return (v, w)
 ~~~
 
@@ -2232,7 +2232,7 @@ Exceptions: none.
 Operations:
 
 ~~~
-1. tv1 = (2 * q - 1) / 3   // Integer arithmetic
+1. tv1 = (2 * q - 1) / 3    # Integer arithmetic
 2.   x = (u^2 - B)^tv1
 3.   y = u
 4. return (x, y)
@@ -2249,12 +2249,12 @@ Input: u, an element of F.
 Output: (x, y), a point on E.
 
 Constants:
-1. c1 = (2 * q - 1) / 3   // Integer arithmetic
+1. c1 = (2 * q - 1) / 3     # Integer arithmetic
 
 Steps:
 1. tv1 = u^2
 2. tv1 = tv1 - B
-3.   x = tv1^c1             // x = (u^2 - B)^((2 * q - 1) / 3)
+3.   x = tv1^c1             # x = (u^2 - B)^((2 * q - 1) / 3)
 4.   y = u
 5. return (x, y)
 ~~~
@@ -2310,15 +2310,15 @@ Input: u, an element of F.
 Output: (x, y), a point on E.
 
 Constants:
-1. c1 = (p + 1) / 4         // Integer arithmetic
+1. c1 = (p + 1) / 4         # Integer arithmetic
 
 Steps:
 1.  x1 = u
 2.  x2 = -x1
 3. gx1 = x1^2
 4. gx1 = gx1 + D
-5. gx1 = gx1 * x1           // gx1 = x1^3 + D * x1
-6.   y = gx1^c1             // This is either sqrt(gx1) or sqrt(gx2)
+5. gx1 = gx1 * x1           # gx1 = x1^3 + D * x1
+6.   y = gx1^c1             # This is either sqrt(gx1) or sqrt(gx2)
 7.  e1 = (y^2) == gx1
 8.   x = CMOV(x2, x1, e1)
 9.  e2 = sgn0(u) == sgn0(y)
@@ -3234,7 +3234,7 @@ Output: (xn, xd, yn, yd) such that (xn / xd, yn / yd) is a
         point on the target curve.
 
 Constants: defined per curve; see above.
-1.  c1 = (p - 3) / 4           // Integer arithmetic
+1.  c1 = (p - 3) / 4           # Integer arithmetic
 2.  c2 = sqrt(-Z^3)
 
 Steps:
@@ -3246,30 +3246,30 @@ Steps:
 6.  x1n = x1n * B
 7.   xd = -A * xd
 8.   e1 = xd == 0
-9.   xd = CMOV(xd, Z * A, e1)  // If xd == 0, set xd = Z * A
+9.   xd = CMOV(xd, Z * A, e1)  # If xd == 0, set xd = Z * A
 10. tv2 = xd^2
-11. gxd = tv2 * xd             // gxd == xd^3
+11. gxd = tv2 * xd             # gxd == xd^3
 12. tv2 = A * tv2
 13. gx1 = x1n^2
-14. gx1 = gx1 + tv2            // x1n^2 + A * xd^2
-15. gx1 = gx1 * x1n            // x1n^3 + A * x1n * xd^2
+14. gx1 = gx1 + tv2            # x1n^2 + A * xd^2
+15. gx1 = gx1 * x1n            # x1n^3 + A * x1n * xd^2
 16. tv2 = B * gxd
-17. gx1 = gx1 + tv2            // x1n^3 + A * x1n * xd^2 + B * xd^3
+17. gx1 = gx1 + tv2            # x1n^3 + A * x1n * xd^2 + B * xd^3
 18. tv4 = gxd^2
 19. tv2 = gx1 * gxd
-20. tv4 = tv4 * tv2            // gx1 * gxd^3
-21.  y1 = tv4^c1               // (gx1 * gxd^3)^((p - 3) / 4)
-22.  y1 = y1 * tv2             // gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
-23. x2n = tv3 * x1n            // x2 = x2n / xd = -10 * u^2 * x1n / xd
-24.  y2 = y1 * c2              // y2 = y1 * sqrt(-Z^3)
+20. tv4 = tv4 * tv2            # gx1 * gxd^3
+21.  y1 = tv4^c1               # (gx1 * gxd^3)^((p - 3) / 4)
+22.  y1 = y1 * tv2             # gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
+23. x2n = tv3 * x1n            # x2 = x2n / xd = -10 * u^2 * x1n / xd
+24.  y2 = y1 * c2              # y2 = y1 * sqrt(-Z^3)
 25.  y2 = y2 * tv1
 26.  y2 = y2 * u
 27. tv2 = y1^2
 28. tv2 = tv2 * gxd
 29.  e2 = tv2 == gx1
-30.  xn = CMOV(x2n, x1n, e2)   // If e2, x = x1, else x = x2
-31.   y = CMOV(y2, y1, e2)     // If e2, y = y1, else y = y2
-32.  e3 = sgn0(u) == sgn0(y)   // Fix sign of y
+30.  xn = CMOV(x2n, x1n, e2)   # If e2, x = x1, else x = x2
+31.   y = CMOV(y2, y1, e2)     # If e2, y = y1, else y = y2
+32.  e3 = sgn0(u) == sgn0(y)   # Fix sign of y
 33.   y = CMOV(-y, y, e3)
 34. return (xn, xd, y, 1)
 ~~~
@@ -3287,50 +3287,50 @@ Output: (xn, xd, yn, yd) such that (xn / xd, yn / yd) is a
         point on curve25519.
 
 Constants:
-1. c1 = (p + 3) / 8           // Integer arithmetic
+1. c1 = (p + 3) / 8           # Integer arithmetic
 2. c2 = 2^c1
 3. c3 = sqrt(-1)
-4. c4 = (p - 5) / 8           // Integer arithmetic
+4. c4 = (p - 5) / 8           # Integer arithmetic
 
 Steps:
 1.  tv1 = u^2
 2.  tv1 = 2 * tv1
-3.   xd = tv1 + 1             // Nonzero: -1 is square (mod p), tv1 is not
-4.  x1n = -486662             // x1 = x1n / xd = -486662 / (1 + 2 * u^2)
+3.   xd = tv1 + 1             # Nonzero: -1 is square (mod p), tv1 is not
+4.  x1n = -486662             # x1 = x1n / xd = -486662 / (1 + 2 * u^2)
 5.  tv2 = xd^2
-6.  gxd = tv2 * xd            // gxd = xd^3
-7.  gx1 = 486662 * xd         // 486662 * xd
-8.  gx1 = gx1 + x1n           // x1n + 486662 * xd
-9.  gx1 = gx1 * x1n           // x1n^2 + 486662 * x1n * xd
-10. gx1 = gx1 + tv2           // x1n^2 + 486662 * x1n * xd + xd^2
-11. gx1 = gx1 * x1n           // x1n^3 + 486662 * x1n^2 * xd + x1n * xd^2
+6.  gxd = tv2 * xd            # gxd = xd^3
+7.  gx1 = 486662 * xd         # 486662 * xd
+8.  gx1 = gx1 + x1n           # x1n + 486662 * xd
+9.  gx1 = gx1 * x1n           # x1n^2 + 486662 * x1n * xd
+10. gx1 = gx1 + tv2           # x1n^2 + 486662 * x1n * xd + xd^2
+11. gx1 = gx1 * x1n           # x1n^3 + 486662 * x1n^2 * xd + x1n * xd^2
 12. tv3 = gxd^2
-13. tv2 = tv3^2               // gxd^4
-14. tv3 = tv3 * gxd           // gxd^3
-15. tv3 = tv3 * gx1           // gx1 * gxd^3
-16. tv2 = tv2 * tv3           // gx1 * gxd^7
-17. y11 = tv2^c4              // (gx1 * gxd^7)^((p - 5) / 8)
-18. y11 = y11 * tv3           // gx1 * gxd^3 * (gx1 * gxd^7)^((p - 5) / 8)
+13. tv2 = tv3^2               # gxd^4
+14. tv3 = tv3 * gxd           # gxd^3
+15. tv3 = tv3 * gx1           # gx1 * gxd^3
+16. tv2 = tv2 * tv3           # gx1 * gxd^7
+17. y11 = tv2^c4              # (gx1 * gxd^7)^((p - 5) / 8)
+18. y11 = y11 * tv3           # gx1 * gxd^3 * (gx1 * gxd^7)^((p - 5) / 8)
 19. y12 = y11 * c3
 20. tv2 = y11^2
 21. tv2 = tv2 * gxd
 22.  e1 = tv2 == gx1
-23.  y1 = CMOV(y12, y11, e1)  // If g(x1) is square, this is its sqrt
-24. x2n = x1n * tv1           // x2 = x2n / xd = 2 * u^2 * x1n / xd
+23.  y1 = CMOV(y12, y11, e1)  # If g(x1) is square, this is its sqrt
+24. x2n = x1n * tv1           # x2 = x2n / xd = 2 * u^2 * x1n / xd
 25. y21 = y11 * u
 26. y21 = y21 * c2
 27. y22 = y21 * c3
-28. gx2 = gx1 * tv1           // g(x2) = gx2 / gxd = 2 * u^2 * g(x1)
+28. gx2 = gx1 * tv1           # g(x2) = gx2 / gxd = 2 * u^2 * g(x1)
 29. tv2 = y21^2
 30. tv2 = tv2 * gxd
 31.  e2 = tv2 == gx2
-32.  y2 = CMOV(y22, y21, e2)  // If g(x2) is square, this is its sqrt
+32.  y2 = CMOV(y22, y21, e2)  # If g(x2) is square, this is its sqrt
 33. tv2 = y1^2
 34. tv2 = tv2 * gxd
 35.  e3 = tv2 == gx1
-36.  xn = CMOV(x2n, x1n, e3)  // If e3, x = x1, else x = x2
-37.   y = CMOV(y2, y1, e3)    // If e3, y = y1, else y = y2
-38.  e4 = sgn0(u) == sgn0(y)  // Fix sign of y
+36.  xn = CMOV(x2n, x1n, e3)  # If e3, x = x1, else x = x2
+37.   y = CMOV(y2, y1, e3)    # If e3, y = y1, else y = y2
+38.  e4 = sgn0(u) == sgn0(y)  # Fix sign of y
 39.   y = CMOV(-y, y, e4)
 40. return (xn, xd, y, 1)
 ~~~
@@ -3350,15 +3350,15 @@ Output: (xn, xd, yn, yd) such that (xn / xd, yn / yd) is a
         point on edwards25519.
 
 Constants:
-1. c1 = sqrt(-486664)   // sgn0(c1) MUST equal 1
+1. c1 = sqrt(-486664)    # sgn0(c1) MUST equal 1
 
 Steps:
 1.  (xMn, xMd, yMn, yMd) = map_to_curve_elligator2_curve25519(u)
 2.  xn = xMn * yMd
 3.  xn = xn * c1
-4.  xd = xMd * yMn       // xn / xd = c1 * xM / yM
+4.  xd = xMd * yMn       # xn / xd = c1 * xM / yM
 5.  yn = xMn - xMd
-6.  yd = xMn + xMd       // (n / d - 1) / (n / d + 1) = (n - d) / (n + d)
+6.  yd = xMn + xMd       # (n / d - 1) / (n / d + 1) = (n - d) / (n + d)
 7. tv1 = xd * yd
 8.   e = tv1 == 0
 9.  xn = CMOV(xn, 0, e)
@@ -3381,35 +3381,35 @@ Output: (xn, xd, yn, yd) such that (xn / xd, yn / yd) is a
         point on curve448.
 
 Constants:
-1. c1 = (p - 3) / 4           // Integer arithmetic
+1. c1 = (p - 3) / 4           # Integer arithmetic
 
 Steps:
 1.  tv1 = u^2
 2.   e1 = tv1 == 1
-3.  tv1 = CMOV(tv1, 0, e1)    // If Z * u^2 == -1, set tv1 = 0
+3.  tv1 = CMOV(tv1, 0, e1)    # If Z * u^2 == -1, set tv1 = 0
 4.   xd = 1 - tv1
 5.  x1n = -156326
 6.  tv2 = xd^2
-7.  gxd = tv2 * xd            // gxd = xd^3
-8.  gx1 = 156326 * xd         // 156326 * xd
-9.  gx1 = gx1 + x1n           // x1n + 156326 * xd
-10. gx1 = gx1 * x1n           // x1n^2 + 156326 * x1n * xd
-11. gx1 = gx1 + tv2           // x1n^2 + 156326 * x1n * xd + xd^2
-12. gx1 = gx1 * x1n           // x1n^3 + 156326 * x1n^2 * xd + x1n * xd^2
+7.  gxd = tv2 * xd            # gxd = xd^3
+8.  gx1 = 156326 * xd         # 156326 * xd
+9.  gx1 = gx1 + x1n           # x1n + 156326 * xd
+10. gx1 = gx1 * x1n           # x1n^2 + 156326 * x1n * xd
+11. gx1 = gx1 + tv2           # x1n^2 + 156326 * x1n * xd + xd^2
+12. gx1 = gx1 * x1n           # x1n^3 + 156326 * x1n^2 * xd + x1n * xd^2
 13. tv3 = gxd^2
-14. tv2 = gx1 * gxd           // gx1 * gxd
-15. tv3 = tv3 * tv2           // gx1 * gxd^3
-16.  y1 = tv3^c1              // (gx1 * gxd^3)^((p - 3) / 4)
-17.  y1 = y1 * tv2            // gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
-18. x2n = -tv1 * x1n          // x2 = x2n / xd = -1 * u^2 * x1n / xd
+14. tv2 = gx1 * gxd           # gx1 * gxd
+15. tv3 = tv3 * tv2           # gx1 * gxd^3
+16.  y1 = tv3^c1              # (gx1 * gxd^3)^((p - 3) / 4)
+17.  y1 = y1 * tv2            # gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
+18. x2n = -tv1 * x1n          # x2 = x2n / xd = -1 * u^2 * x1n / xd
 19.  y2 = y1 * u
 20.  y2 = CMOV(y2, 0, e1)
 21. tv2 = y1^2
 22. tv2 = tv2 * gxd
 23.  e2 = tv2 == gx1
-24.  xn = CMOV(x2n, x1n, e2)  // If e2, x = x1, else x = x2
-25.   y = CMOV(y2, y1, e2)    // If e2, y = y1, else y = y2
-26.  e3 = sgn0(u) == sgn0(y)  // Fix sign of y
+24.  xn = CMOV(x2n, x1n, e2)  # If e2, x = x1, else x = x2
+25.   y = CMOV(y2, y1, e2)    # If e2, y = y1, else y = y2
+26.  e3 = sgn0(u) == sgn0(y)  # Fix sign of y
 27.   y = CMOV(-y, y, e3)
 28. return (xn, xd, y, 1)
 ~~~
@@ -3569,7 +3569,7 @@ Input: x, an element of F.
 Output: z, an element of F such that (z^2) == x, if x is square in F.
 
 Constants:
-1. c1 = (q + 1) / 4     // Integer arithmetic
+1. c1 = (q + 1) / 4     # Integer arithmetic
 
 Procedure:
 1. return x^c1
@@ -3588,7 +3588,7 @@ Output: z, an element of F such that (z^2) == x, if x is square in F.
 
 Constants:
 1. c1 = sqrt(-1) in F, i.e., (c1^2) == -1 in F
-2. c2 = (q + 3) / 8     // Integer arithmetic
+2. c2 = (q + 3) / 8     # Integer arithmetic
 
 Procedure:
 1. tv1 = x^c2
@@ -3612,7 +3612,7 @@ Constants:
 1. c1 = sqrt(-1) in F, i.e., (c1^2) == -1 in F
 2. c2 = sqrt(c1) in F, i.e., (c2^2) == c1 in F
 3. c3 = sqrt(-c1) in F, i.e., (c3^2) == -c1 in F
-4. c4 = (q + 7) / 16    // Integer arithmetic
+4. c4 = (q + 7) / 16         # Integer arithmetic
 
 Procedure:
 1. tv1 = x^c4
@@ -3621,10 +3621,10 @@ Procedure:
 4. tv4 = c3 * tv1
 5.  e1 = (tv2^2) == x
 6.  e2 = (tv3^2) == x
-7. tv1 = CMOV(tv1, tv2, e1)  // Select tv2 if (tv2^2) == x
-8. tv2 = CMOV(tv4, tv3, e2)  // Select tv3 if (tv3^2) == x
+7. tv1 = CMOV(tv1, tv2, e1)  # Select tv2 if (tv2^2) == x
+8. tv2 = CMOV(tv4, tv3, e2)  # Select tv3 if (tv3^2) == x
 9.  e3 = (tv2^2) == x
-10.  z = CMOV(tv1, tv2, e3)  // Select the sqrt from tv1 and tv2
+10.  z = CMOV(tv1, tv2, e3)  # Select the sqrt from tv1 and tv2
 11. return z
 ~~~
 
@@ -3649,8 +3649,8 @@ Output: z, an element of F such that z^2 == x, if x is square in F.
 
 Constants:
 1. c1, the largest integer such that 2^c1 divides q - 1.
-2. c2 = (q - 1) / (2^c1)        // Integer arithmetic
-3. c3 = (c2 - 1) / 2            // Integer arithmetic
+2. c2 = (q - 1) / (2^c1)        # Integer arithmetic
+3. c3 = (c2 - 1) / 2            # Integer arithmetic
 4. c4, a non-square value in F
 5. c5 = c4^c2 in F
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1008,9 +1008,11 @@ The following is a brief definition of elliptic curves, with an emphasis on
 important parameters and their relation to hashing to curves.
 For further reference on elliptic curves, consult {{CFADLNV05}} or {{W08}}.
 
-Let F be the finite field GF(q) of prime characteristic p. In most cases F
-is a prime field, so q = p. Otherwise, F is an extension field, so q = p^m for
-an integer m > 1. This document writes elements of extension fields
+Let F be the finite field GF(q) of prime characteristic p > 3.
+(This document does not consider elliptic curves over fields of characteristic 2 or 3.)
+In most cases F is a prime field, so q = p.
+Otherwise, F is an extension field, so q = p^m for an integer m > 1.
+This document writes elements of extension fields
 in a primitive element or polynomial basis, i.e., as a vector
 of m elements of GF(p) written in ascending order by degree.
 The entries of this vector are indexed in ascending order starting from 1,
@@ -1719,8 +1721,7 @@ first evaluate the Shallue-van de Woestijne mapping to an equivalent Weierstrass
 curve, then map that point to the target Montgomery or twisted Edwards curve
 using the corresponding rational map.
 
-Preconditions: A Weierstrass curve y^2 = x^3 + A * x + B over F = GF(p^m)
-where p > 5 and odd.
+Preconditions: A Weierstrass curve y^2 = x^3 + A * x + B.
 
 Constants:
 
@@ -1821,10 +1822,10 @@ Steps:
 The function map\_to\_curve\_simple\_swu(u) implements a simplification
 of the Shallue-van de Woestijne-Ulas mapping {{U07}} described by Brier et
 al. {{BCIMRT10}}, which they call the "simplified SWU" map. Wahby and Boneh
-{{WB19}} generalize this mapping to curves over fields of odd characteristic p > 3.
+{{WB19}} generalize and optimize this mapping.
 
-Preconditions: A Weierstrass curve y^2 = x^3 + A * x + B over F = GF(p^m)
-where p > 5 and odd, A != 0, and B != 0.
+Preconditions: A Weierstrass curve y^2 = x^3 + A * x + B,
+where A != 0 and B != 0.
 
 Constants:
 
@@ -2960,7 +2961,6 @@ The rational map from the point (s, t) on the Montgomery curve
     B' * t^2 = s^3 + A' * s^2 + s
 ~~~
 
-over a field F = GF(p^m), p > 3,
 to the point (x, y) on the equivalent Weierstrass curve
 
 ~~~

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -3592,9 +3592,10 @@ Constants:
 
 Procedure:
 1. tv1 = x^c2
-2.   e = (tv1^2) == x
-3.   z = CMOV(tv1 * c1, tv1, e)
-3. return z
+2. tv2 = tv1 * c1
+3.   e = (tv1^2) == x
+4.   z = CMOV(tv2, tv1, e)
+5. return z
 ~~~
 
 ## q = 9 (mod 16) {#sqrt-9mod16}

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -813,6 +813,27 @@ informative:
         ins: J. F. Voloch
         name: J. Felipe Voloch
         org: University of Texas
+  MRH04:
+    title: "Indifferentiability, impossibility results on reductions, and applications to the random oracle methodology"
+    seriesinfo:
+      "In": "TCC 2004: Theory of Cryptography"
+      "pages": 21-39
+      DOI: 10.1007/978-3-540-24638-1_2
+    target: https://doi.org/10.1007/978-3-540-24638-1_2
+    date: Feb, 2004
+    author:
+      -
+        ins: U. Maurer
+        name: Ueli Maurer
+        org: ETH Zurich
+      -
+        ins: R. Renner
+        name: Renato Renner
+        org: ETH Zurich
+      -
+        ins: C. Holenstein
+        name: Clemens Holenstein
+        org: ETH Zurich
   S85:
     title: Elliptic Curves Over Finite Fields and the Computation of Square Roots mod p
     seriesinfo:
@@ -1098,12 +1119,16 @@ Because in general the mapping is not surjective, the output of this
 construction is distinguishable from uniformly random, i.e., it does
 not behave like a random oracle.
 
-Brier et al. {{BCIMRT10}} describe two generic constructions whose outputs are
-indifferentiable from a random oracle when the constructions are instantiated
-with appropriate hash functions modeled as random oracles.
+Brier et al. {{BCIMRT10}} describe two generic methods for constructing
+random oracle encodings.
 Farashahi et al. {{FFSTV13}} and Tibouchi and Kim {{TK17}} refine the analysis
 of one of these constructions.
 That construction is described in {{roadmap}}.
+
+(In more detail: both constructions are
+indifferentiable from a random oracle {{MRH04}} when instantiated
+with appropriate hash functions modeled as random oracles.
+See {{security-considerations}} for further discussion.)
 
 ### Serialization {#term-serialization}
 
@@ -2723,7 +2748,7 @@ Budroni and Pintore ({{BP18}}, Section 4.1).
 
 This document has no IANA actions.
 
-# Security Considerations
+# Security Considerations {#security-considerations}
 
 When constant-time implementations are required, all basic operations and
 utility functions must be implemented in constant time, as discussed in
@@ -2743,7 +2768,7 @@ for random oracle encodings.
 
 When the hash\_to\_curve function ({{roadmap}}) is instantiated
 with hash\_to\_base ({{hashtobase}}), the resulting function is
-indifferentiable from a random oracle.
+indifferentiable from a random oracle ({{FFSTV13}}, {{LBB19}}, {{MRH04}}).
 In most cases such a function can be safely used in protocols whose security
 analysis assumes a random oracle that outputs points on an elliptic curve.
 As Ristenpart et al. discuss in {{RSS11}}, however, not all security proofs

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1660,7 +1660,7 @@ As a rough guide, the following conventions are used in pseudocode:
 - u: the input to the mapping function.
   This is an element of F produced by the hash\_to\_base function.
 
-- (x, y): the affine coordinates of the point output by the mapping.
+- (x, y), (X, Y), (v, w): the affine coordinates of the point output by the mapping.
   Indexed variables (e.g., x1, y2, ...) are used for candidate values.
 
 - tv1, tv2, ...: reusable temporary variables.
@@ -2005,25 +2005,25 @@ Constants:
 - Z, a non-square element of F.
   {{elligator-z-code}} gives a Sage {{SAGE}} script that outputs the RECOMMENDED Z.
 
-Sign of Y: Inputs u and -u give the same x-coordinate.
+Sign of Y: Inputs u and -u give the same X-coordinate.
 Thus, we set sgn0(Y) == sgn0(u).
 
 Exceptions: The exceptional case is Z * u^2 == -1, i.e., 1 + Z * u^2 == 0.
-Implementations must detect this case and set x1 = -C.
+Implementations must detect this case and set X1 = -C.
 Note that this can only happen when q = 3 (mod 4).
 
 Operations:
 
 ~~~
-1.  x1 = -C * inv0(1 + Z * u^2)
-2.  If x1 == 0, set x1 = -C.
-3. gx1 = x1^3 + C * x1^2 + D * x1
-4.  x2 = -x1 - C
-5. gx2 = x2^3 + C * x2^2 + D * x2
-6.  If is_square(gx1), set x = x1 and y = sqrt(gx1)
-7.  Else set x = x2 and y = sqrt(gx2)
-8.  If sgn0(u) != sgn0(y), set y = -y
-9.  return (x, y)
+1.  X1 = -C * inv0(1 + Z * u^2)
+2.  If X1 == 0, set X1 = -C.
+3. gX1 = X1^3 + C * X1^2 + D * X1
+4.  X2 = -X1 - C
+5. gX2 = X2^3 + C * X2^2 + D * X2
+6.  If is_square(gX1), set X = X1 and Y = sqrt(gX1)
+7.  Else set X = X2 and Y = sqrt(gX2)
+8.  If sgn0(u) != sgn0(Y), set Y = -Y
+9.  return (X, Y)
 ~~~
 
 #### Implementation
@@ -2035,29 +2035,29 @@ curve448 {{RFC7748}}.
 ~~~
 map_to_curve_elligator2(u)
 Input: u, an element of F.
-Output: (x, y), a point on E.
+Output: (X, Y), a point on E.
 
 Steps:
 1.  tv1 = u^2
 2.  tv1 = Z * tv1             # Z * u^2
 3.   e1 = tv1 == -1           # exceptional case: Z * u^2 == -1
 4.  tv1 = CMOV(tv1, 0, e1)    # if tv1 == -1, set tv1 = 0
-5.   x1 = tv1 + 1
-6.   x1 = inv0(x1)
-7.   x1 = -C * x1             # x1 = -C / (1 + Z * u^2)
-8.  gx1 = x1 + C
-9.  gx1 = gx1 * x1
-10. gx1 = gx1 + D
-11. gx1 = gx1 * x1            # gx1 = x1^3 + C * x1^2 + D * x1
-12.  x2 = -x1 - C
-13. gx2 = tv1 * gx1
-14.  e2 = is_square(gx1)
-15.   x = CMOV(x2, x1, e2)    # If is_square(gx1), x = x1, else x = x2
-16.  y2 = CMOV(gx2, gx1, e2)  # If is_square(gx1), y2 = gx1, else y2 = gx2
-17.   y = sqrt(y2)
-18.  e3 = sgn0(u) == sgn0(y)  # Fix sign of y
-19.   y = CMOV(-y, y, e3)
-20. return (x, y)
+5.   X1 = tv1 + 1
+6.   X1 = inv0(X1)
+7.   X1 = -C * X1             # X1 = -C / (1 + Z * u^2)
+8.  gX1 = X1 + C
+9.  gX1 = gX1 * X1
+10. gX1 = gX1 + D
+11. gX1 = gX1 * X1            # gX1 = X1^3 + C * X1^2 + D * X1
+12.  X2 = -X1 - C
+13. gX2 = tv1 * gX1
+14.  e2 = is_square(gX1)
+15.   X = CMOV(X2, X1, e2)    # If is_square(gX1), X = X1, else X = X2
+16.  Y2 = CMOV(gX2, gX1, e2)  # If is_square(gX1), Y2 = gX1, else Y2 = gX2
+17.   Y = sqrt(Y2)
+18.  e3 = sgn0(u) == sgn0(Y)  # Fix sign of Y
+19.   Y = CMOV(-Y, Y, e3)
+20. return (X, Y)
 ~~~
 
 ## Mappings for Twisted Edwards curves {#twisted-edwards}
@@ -2156,18 +2156,18 @@ Implementations of other rational maps (e.g., the ones give in {{RFC7748}})
 are analogous.
 
 ~~~
-rational_map(x, y)
-Input: (x, y), a point on the curve Y^2 = X^3 + C * X^2 + D * X.
+rational_map(X, Y)
+Input: (X, Y), a point on the curve Y^2 = X^3 + C * X^2 + D * X.
 Output: (v, w), a point on an equivalent twisted Edwards curve.
 
-1. tv1 = x * invSqrtD
+1. tv1 = X * invSqrtD
 2. tv2 = tv1 + 1
-3. tv3 = y * tv2
+3. tv3 = Y * tv2
 4. tv3 = inv0(tv3)
 5.   v = tv2 * tv3
-6.   v = v * x
+6.   v = v * X
 7.   w = tv1 - 1
-8.   w = w * y
+8.   w = w * Y
 9.   w = w * tv3
 10.  e = w == 0
 11.  w = CMOV(w, 1, e)
@@ -2203,8 +2203,8 @@ map_to_curve_elligator2_edwards(u)
 Input: u, an element of F.
 Output: (v, w), a point on E.
 
-1. (x, y) = map_to_curve_elligator2(u)      # (x, y) is on M
-2. (v, w) = rational_map(x, y)              # (v, w) is on E
+1. (X, Y) = map_to_curve_elligator2(u)      # (X, Y) is on M
+2. (v, w) = rational_map(X, Y)              # (v, w) is on E
 3. return (v, w)
 ~~~
 
@@ -2261,7 +2261,7 @@ Steps:
 
 ### Elligator 2, C == 0 Method {#ell2c0}
 
-The function map\_to\_curve\_ell2A0(u) implements an adaptation of Elligator 2
+The function map\_to\_curve\_ell2C0(u) implements an adaptation of Elligator 2
 {{BLMP19}} targeting curves given by the Weierstrass equation
 
 ~~~
@@ -2281,22 +2281,22 @@ Preconditions: A curve whose equation and base field meet the requirements immed
 
 Constants: D, the parameter of the elliptic curve.
 
-Sign of y: Inputs u and -u give the same x-coordinate.
-Thus, we set sgn0(y) == sgn0(u).
+Sign of Y: Inputs u and -u give the same X-coordinate.
+Thus, we set sgn0(Y) == sgn0(u).
 
 Exceptions: none.
 
 Operations:
 
 ~~~
-1.  x1 = u
-2. gx1 = x1^3 + D * x1
-3.  x2 = -x1
-4. gx2 = -gx1
-5. If is_square(gx1), set x = x1 and y = sqrt(gx1)
-6. Else set x = x2 and y = sqrt(gx2)
-7. If sgn0(u) != sgn0(y), set y = -y.
-8. return (x, y)
+1.  X1 = u
+2. gX1 = X1^3 + D * X1
+3.  X2 = -X1
+4. gX2 = -gX1
+5. If is_square(gX1), set X = X1 and Y = sqrt(gX1)
+6. Else set X = X2 and Y = sqrt(gX2)
+7. If sgn0(u) != sgn0(Y), set Y = -Y.
+8. return (X, Y)
 ~~~
 
 #### Implementation
@@ -2307,23 +2307,23 @@ in a straight-line fashion.
 ~~~
 map_to_curve_ell2C0(u)
 Input: u, an element of F.
-Output: (x, y), a point on E.
+Output: (X, Y), a point on E.
 
 Constants:
 1. c1 = (q + 1) / 4         # Integer arithmetic
 
 Steps:
-1.  x1 = u
-2.  x2 = -x1
-3. gx1 = x1^2
-4. gx1 = gx1 + D
-5. gx1 = gx1 * x1           # gx1 = x1^3 + D * x1
-6.   y = gx1^c1             # This is either sqrt(gx1) or sqrt(gx2)
-7.  e1 = (y^2) == gx1
-8.   x = CMOV(x2, x1, e1)
-9.  e2 = sgn0(u) == sgn0(y)
-10.  y = CMOV(-y, y, e2)
-11. return (x, y)
+1.  X1 = u
+2.  X2 = -X1
+3. gX1 = X1^2
+4. gX1 = gX1 + D
+5. gX1 = gX1 * X1           # gX1 = X1^3 + D * X1
+6.   Y = gX1^c1             # This is either sqrt(gX1) or sqrt(gX2)
+7.  e1 = (Y^2) == gX1
+8.   X = CMOV(X2, X1, e1)
+9.  e2 = sgn0(u) == sgn0(Y)
+10.  Y = CMOV(-Y, Y, e2)
+11. return (X, Y)
 ~~~
 
 # Clearing the cofactor {#cofactor-clearing}

--- a/poc/README.md
+++ b/poc/README.md
@@ -54,7 +54,7 @@ The following files implement the deterministic mappings:
 
 - Boneh-Franklin: `bf_generic.sage`
 
-- Elligator 2, A == 0: `ell2a0_generic.sage`
+- Elligator 2, C == 0: `ell2c0_generic.sage`
 
 All of these have the same interface: they define a class (e.g., `GenericSvdW` for
 the Shallue-van de Woestijne map) that takes as arguments the field `F` (constructed

--- a/poc/bf_generic.sage
+++ b/poc/bf_generic.sage
@@ -27,8 +27,8 @@ class GenericBF(GenericMap):
         u = self.F(u)
         B = self.B
 
-        w = (2 * q - 1) // 3
-        x = (u^2 - B)^w
+        tv1 = (2 * q - 1) // 3    # Integer arithmetic
+        x = (u^2 - B)^tv1
         y = u
         return (x, y)
 
@@ -37,9 +37,9 @@ class GenericBF(GenericMap):
         B = self.B
         c1 = self.c1
 
-        t1 = u^2
-        t1 = t1 - B
-        x = t1^c1
+        tv1 = u^2
+        tv1 = tv1 - B
+        x = tv1^c1             # x = (u^2 - B)^((2 * q - 1) / 3)
         y = u
         return (x, y)
 

--- a/poc/common.sage
+++ b/poc/common.sage
@@ -107,21 +107,20 @@ def tonelli_shanks_ct(x):
         ts_precompute(p, F)
 
     (q, m, c) = sqrt_cache[p]
-    r = x ** ((q - 1) // 2)
-    t = r * r * x
-    r *= x
+    z = x ** ((q - 1) // 2)
+    t = z * z * x
+    z = z * x
     b = t
-    for k in range(m, 1, -1):
-        for _ in range(1, k - 1):
-            b *= b
-        b_is_good = b != F(1)
-        r = CMOV(r, r * c, b_is_good)
-        c *= c
-        t = CMOV(t, t * c, b_is_good)
+    for i in range(m, 1, -1):
+        for _ in range(1, i - 1):
+             b = b * b
+        z = CMOV(z, z * c, b != 1)
+        c = c * c
+        t = CMOV(t, t * c, b != 1)
         b = t
 
-    if r ** 2 == x:
-        return r
+    if z ** 2 == x:
+        return z
     assert not x.is_square()
     return None
 

--- a/poc/ell2_25519_opt.sage
+++ b/poc/ell2_25519_opt.sage
@@ -24,44 +24,44 @@ def map_to_curve_elligator2_curve25519(u):
     c3 = sqrt(F(-1))
     c4 = (p - 5) // 8
 
-    t1 = u^2
-    t1 = 2 * t1
-    xd = t1 + 1
-    x1n = -486662
-    t2 = xd^2
-    gxd = t2 * xd
-    gx1 = 486662 * xd
-    gx1 = gx1 + x1n
-    gx1 = gx1 * x1n
-    gx1 = gx1 + t2
-    gx1 = gx1 * x1n
-    t3 = gxd^2
-    t2 = t3^2
-    t3 = t3 * gxd
-    t3 = t3 * gx1
-    t2 = t2 * t3
-    y11 = t2^c4
-    y11 = y11 * t3
+    tv1 = u^2
+    tv1 = 2 * tv1
+    xd = tv1 + 1             # Nonzero: -1 is square (mod p), tv1 is not
+    x1n = -486662             # x1 = x1n / xd = -486662 / (1 + 2 * u^2)
+    tv2 = xd^2
+    gxd = tv2 * xd            # gxd = xd^3
+    gx1 = 486662 * xd         # 486662 * xd
+    gx1 = gx1 + x1n           # x1n + 486662 * xd
+    gx1 = gx1 * x1n           # x1n^2 + 486662 * x1n * xd
+    gx1 = gx1 + tv2           # x1n^2 + 486662 * x1n * xd + xd^2
+    gx1 = gx1 * x1n           # x1n^3 + 486662 * x1n^2 * xd + x1n * xd^2
+    tv3 = gxd^2
+    tv2 = tv3^2               # gxd^4
+    tv3 = tv3 * gxd           # gxd^3
+    tv3 = tv3 * gx1           # gx1 * gxd^3
+    tv2 = tv2 * tv3           # gx1 * gxd^7
+    y11 = tv2^c4              # (gx1 * gxd^7)^((p - 5) / 8)
+    y11 = y11 * tv3           # gx1 * gxd^3 * (gx1 * gxd^7)^((p - 5) / 8)
     y12 = y11 * c3
-    t2 = y11^2
-    t2 = t2 * gxd
-    e1 = t2 == gx1
-    y1 = CMOV(y12, y11, e1)
-    x2n = x1n * t1
+    tv2 = y11^2
+    tv2 = tv2 * gxd
+    e1 = tv2 == gx1
+    y1 = CMOV(y12, y11, e1)  # If g(x1) is square, this is its sqrt
+    x2n = x1n * tv1           # x2 = x2n / xd = 2 * u^2 * x1n / xd
     y21 = y11 * u
     y21 = y21 * c2
     y22 = y21 * c3
-    gx2 = gx1 * t1
-    t2 = y21^2
-    t2 = t2 * gxd
-    e2 = t2 == gx2
-    y2 = CMOV(y22, y21, e2)
-    t2 = y1^2
-    t2 = t2 * gxd
-    e3 = t2 == gx1
-    xn = CMOV(x2n, x1n, e3)
-    y = CMOV(y2, y1, e3)
-    e4 = sgn0(u) == sgn0(y)
+    gx2 = gx1 * tv1           # g(x2) = gx2 / gxd = 2 * u^2 * g(x1)
+    tv2 = y21^2
+    tv2 = tv2 * gxd
+    e2 = tv2 == gx2
+    y2 = CMOV(y22, y21, e2)  # If g(x2) is square, this is its sqrt
+    tv2 = y1^2
+    tv2 = tv2 * gxd
+    e3 = tv2 == gx1
+    xn = CMOV(x2n, x1n, e3)  # If e3, x = x1, else x = x2
+    y = CMOV(y2, y1, e3)    # If e3, y = y1, else y = y2
+    e4 = sgn0(u) == sgn0(y)  # Fix sign of y
     y = CMOV(-y, y, e4)
     return (xn, xd, y, 1)
 
@@ -73,11 +73,11 @@ def map_to_curve_elligator2_edwards25519(u):
     (xMn, xMd, yMn, yMd) = map_to_curve_elligator2_curve25519(u)
     xn = xMn * yMd
     xn = xn * c1
-    xd = xMd * yMn
+    xd = xMd * yMn       # xn / xd = c1 * xM / yM
     yn = xMn - xMd
-    yd = xMn + xMd
-    t1 = xd * yd
-    e = t1 == 0
+    yd = xMn + xMd       # (n / d - 1) / (n / d + 1) = (n - d) / (n + d)
+    tv1 = xd * yd
+    e = tv1 == 0
     xn = CMOV(xn, 0, e)
     xd = CMOV(xd, 1, e)
     yn = CMOV(yn, 1, e)

--- a/poc/ell2_448_opt.sage
+++ b/poc/ell2_448_opt.sage
@@ -21,32 +21,32 @@ ref_map.set_sqrt(sqrt)
 def map_to_curve_elligator2_curve448(u):
     c1 = (p - 3) // 4
 
-    t1 = u^2
-    e1 = t1 == 1
-    t1 = CMOV(t1, 0, e1)
-    xd = 1 - t1
+    tv1 = u^2
+    e1 = tv1 == 1
+    tv1 = CMOV(tv1, 0, e1)    # If Z * u^2 == -1, set tv1 = 0
+    xd = 1 - tv1
     x1n = -156326
-    t2 = xd^2
-    gxd = t2 * xd
-    gx1 = 156326 * xd
-    gx1 = gx1 + x1n
-    gx1 = gx1 * x1n
-    gx1 = gx1 + t2
-    gx1 = gx1 * x1n
-    t3 = gxd^2
-    t2 = gx1 * gxd
-    t3 = t3 * t2
-    y1 = t3^c1
-    y1 = y1 * t2
-    x2n = -t1 * x1n
+    tv2 = xd^2
+    gxd = tv2 * xd            # gxd = xd^3
+    gx1 = 156326 * xd         # 156326 * xd
+    gx1 = gx1 + x1n           # x1n + 156326 * xd
+    gx1 = gx1 * x1n           # x1n^2 + 156326 * x1n * xd
+    gx1 = gx1 + tv2           # x1n^2 + 156326 * x1n * xd + xd^2
+    gx1 = gx1 * x1n           # x1n^3 + 156326 * x1n^2 * xd + x1n * xd^2
+    tv3 = gxd^2
+    tv2 = gx1 * gxd           # gx1 * gxd
+    tv3 = tv3 * tv2           # gx1 * gxd^3
+    y1 = tv3^c1              # (gx1 * gxd^3)^((p - 3) / 4)
+    y1 = y1 * tv2            # gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
+    x2n = -tv1 * x1n          # x2 = x2n / xd = -1 * u^2 * x1n / xd
     y2 = y1 * u
     y2 = CMOV(y2, 0, e1)
-    t2 = y1^2
-    t2 = t2 * gxd
-    e2 = t2 == gx1
-    xn = CMOV(x2n, x1n, e2)
-    y = CMOV(y2, y1, e2)
-    e3 = sgn0(u) == sgn0(y)
+    tv2 = y1^2
+    tv2 = tv2 * gxd
+    e2 = tv2 == gx1
+    xn = CMOV(x2n, x1n, e2)  # If e2, x = x1, else x = x2
+    y = CMOV(y2, y1, e2)    # If e2, y = y1, else y = y2
+    e3 = sgn0(u) == sgn0(y)  # Fix sign of y
     y = CMOV(-y, y, e3)
     return (xn, xd, y, 1)
 
@@ -58,32 +58,32 @@ def map_to_curve_elligator2_edwards448(u):
     yn2 = yn^2
     yd2 = yd^2
     xEn = xn2 - xd2
-    t2 = xEn - xd2
+    tv2 = xEn - xd2
     xEn = xEn * xd2
     xEn = xEn * yd
     xEn = xEn * yn
     xEn = xEn * 4
-    t2 = t2 * xn2
-    t2 = t2 * yd2
-    t3 = 4 * yn2
-    t1 = t3 + yd2
-    t1 = t1 * xd4
-    xEd = t1 + t2
-    t2 = t2 * xn
-    t4 = xn * xd4
-    yEn = t3 - yd2
-    yEn = yEn * t4
-    yEn = yEn - t2
-    t1 = xn2 + xd2
-    t1 = t1 * xd2
-    t1 = t1 * xd
-    t1 = t1 * yn2
-    t1 = -2 * t1
-    yEd = t2 + t1
-    t4 = t4 * yd2
-    yEd = yEd + t4
-    t1 = xEd * yEd
-    e = t1 == 0
+    tv2 = tv2 * xn2
+    tv2 = tv2 * yd2
+    tv3 = 4 * yn2
+    tv1 = tv3 + yd2
+    tv1 = tv1 * xd4
+    xEd = tv1 + tv2
+    tv2 = tv2 * xn
+    tv4 = xn * xd4
+    yEn = tv3 - yd2
+    yEn = yEn * tv4
+    yEn = yEn - tv2
+    tv1 = xn2 + xd2
+    tv1 = tv1 * xd2
+    tv1 = tv1 * xd
+    tv1 = tv1 * yn2
+    tv1 = -2 * tv1
+    yEd = tv2 + tv1
+    tv4 = tv4 * yd2
+    yEd = yEd + tv4
+    tv1 = xEd * yEd
+    e = tv1 == 0
     xEn = CMOV(xEn, 0, e)
     xEd = CMOV(xEd, 1, e)
     yEn = CMOV(yEn, 1, e)

--- a/poc/ell2_generic.sage
+++ b/poc/ell2_generic.sage
@@ -35,25 +35,25 @@ class GenericEll2(GenericMap):
         sgn0 = self.sgn0
         sqrt = self.sqrt
         u = self.F(u)
-        A = self.A
-        B = self.B
+        C = self.A
+        D = self.B
         Z = self.Z
 
-        x1 = -A * inv0(1 + Z * u^2)
-        if x1 == 0:
-            x1 = -A
-        gx1 = x1^3 + A * x1^2 + B * x1
-        x2 = -x1 - A
-        gx2 = x2^3 + A * x2^2 + B * x2
-        if is_square(gx1):
-            x = x1
-            y = sqrt(gx1)
+        X1 = -C * inv0(1 + Z * u^2)
+        if X1 == 0:
+            X1 = -C
+        gX1 = X1^3 + C * X1^2 + D * X1
+        X2 = -X1 - C
+        gX2 = X2^3 + C * X2^2 + D * X2
+        if is_square(gX1):
+            X = X1
+            Y = sqrt(gX1)
         else:
-            x = x2
-            y = sqrt(gx2)
-        if sgn0(u) != sgn0(y):
-            y = -y
-        return (x, y)
+            X = X2
+            Y = sqrt(gX2)
+        if sgn0(u) != sgn0(Y):
+            Y = -Y
+        return (X, Y)
 
     def straight_line(self, u):
         inv0 = self.inv0
@@ -61,30 +61,30 @@ class GenericEll2(GenericMap):
         sgn0 = self.sgn0
         sqrt = self.sqrt
         u = self.F(u)
-        A = self.A
-        B = self.B
+        C = self.A
+        D = self.B
         Z = self.Z
 
-        t1 = u^2
-        t1 = Z * t1                 # Z * u^2
-        e1 = t1 == -1               # detect exceptional case
-        t1 = CMOV(t1, 0, e1)        # if t1 == -1, set t1 = 0
-        x1 = t1 + 1
-        x1 = inv0(x1)
-        x1 = -A * x1                # x1 = -A / (1 + Z * u^2)
-        gx1 = x1 + A
-        gx1 = gx1 * x1
-        gx1 = gx1 + B
-        gx1 = gx1 * x1              # gx1 = x1^3 + A * x1^2 + B * x1
-        x2 = -x1 - A
-        gx2 = t1 * gx1
-        e2 = is_square(gx1)
-        x = CMOV(x2, x1, e2)        # If is_square(gx1), x = x1, else x = x2
-        y2 = CMOV(gx2, gx1, e2)     # If is_square(gx1), y2 = gx1, else y2 = gx2
-        y = sqrt(y2)
-        e3 = sgn0(u) == sgn0(y)     # Fix sign of y
-        y = CMOV(-y, y, e3)
-        return (x, y)
+        tv1 = u^2
+        tv1 = Z * tv1             # Z * u^2
+        e1 = tv1 == -1           # exceptional case: Z * u^2 == -1
+        tv1 = CMOV(tv1, 0, e1)    # if tv1 == -1, set tv1 = 0
+        X1 = tv1 + 1
+        X1 = inv0(X1)
+        X1 = -C * X1             # X1 = -C / (1 + Z * u^2)
+        gX1 = X1 + C
+        gX1 = gX1 * X1
+        gX1 = gX1 + D
+        gX1 = gX1 * X1            # gX1 = X1^3 + C * X1^2 + D * X1
+        X2 = -X1 - C
+        gX2 = tv1 * gX1
+        e2 = is_square(gX1)
+        X = CMOV(X2, X1, e2)    # If is_square(gX1), X = X1, else X = X2
+        Y2 = CMOV(gX2, gX1, e2)  # If is_square(gX1), Y2 = gX1, else Y2 = gX2
+        Y = sqrt(Y2)
+        e3 = sgn0(u) == sgn0(Y)  # Fix sign of Y
+        Y = CMOV(-Y, Y, e3)
+        return (X, Y)
 
 if __name__ == "__main__":
     for _ in range(0, 32):

--- a/poc/ell2c0_generic.sage
+++ b/poc/ell2c0_generic.sage
@@ -8,15 +8,15 @@ try:
 except ImportError:
     sys.exit("Error loading preprocessed sage files. Try running `make clean pyfiles`")
 
-class GenericEll2A0(GenericMap):
+class GenericEll2C0(GenericMap):
     def __init__(self, F, _, B):
         self.F = F
         q = F.order()
-        assert q % 4 == 3, "Ell2A0 requires F = GF(q), q = 3 (mod 4)"
+        assert q % 4 == 3, "Ell2C0 requires F = GF(q), q = 3 (mod 4)"
         A = F(0)
         B = F(B)
         test = A**2 - 4 * B
-        assert test != 0 and not test.is_square(), "Ell2A0 requires -4B != 0 and nonsquare"
+        assert test != 0 and not test.is_square(), "Ell2C0 requires -4B != 0 and nonsquare"
         self.A = A
         self.B = B
         self.Z = None
@@ -30,40 +30,40 @@ class GenericEll2A0(GenericMap):
         sgn0 = self.sgn0
         sqrt = self.sqrt
         u = self.F(u)
-        B = self.B
+        D = self.B
 
-        x1 = u
-        gx1 = x1^3 + B * x1
-        x2 = -x1
-        gx2 = -gx1
-        if is_square(gx1):
-            x = x1
-            y = sqrt(gx1)
+        X1 = u
+        gX1 = X1^3 + D * X1
+        X2 = -X1
+        gX2 = -gX1
+        if is_square(gX1):
+            X = X1
+            Y = sqrt(gX1)
         else:
-            x = x2
-            y = sqrt(gx2)
-        if sgn0(u) != sgn0(y):
-            y = -y
-        return (x, y)
+            X = X2
+            Y = sqrt(gX2)
+        if sgn0(u) != sgn0(Y):
+            Y = -Y
+        return (X, Y)
 
     def straight_line(self, u):
         sgn0 = self.sgn0
         u = self.F(u)
-        B = self.B
+        D = self.B
         c1 = self.c1
 
-        x1 = u
-        x2 = -x1
-        gx1 = x1^2
-        gx1 = gx1 + B
-        gx1 = gx1 * x1
-        y = gx1^c1
-        e1 = (y^2) == gx1
-        x = CMOV(x2, x1, e1)
-        e2 = sgn0(u) == sgn0(y)
-        y = CMOV(-y, y, e2)
-        return (x, y)
+        X1 = u
+        X2 = -X1
+        gX1 = X1^2
+        gX1 = gX1 + D
+        gX1 = gX1 * X1           # gX1 = X1^3 + D * X1
+        Y = gX1^c1             # This is either sqrt(gX1) or sqrt(gX2)
+        e1 = (Y^2) == gX1
+        X = CMOV(X2, X1, e1)
+        e2 = sgn0(u) == sgn0(Y)
+        Y = CMOV(-Y, Y, e2)
+        return (X, Y)
 
 if __name__ == "__main__":
     for _ in range(0, 32):
-        GenericEll2A0.test_random()
+        GenericEll2C0.test_random()

--- a/poc/ell2edw_generic.sage
+++ b/poc/ell2edw_generic.sage
@@ -38,22 +38,23 @@ class GenericEll2Edw(GenericMap):
         (xp, yp) = self.ell2_map.not_straight_line(u)
         return self.nsl_map(xp, yp)
 
-    def nsl_map(self, xp, yp):
-        Bp = self.Bp
+    def nsl_map(self, X, Y):
+        invSqrtD = self.Bp
 
-        xnum = xp
-        xden = yp
-        ynum = Bp * xp - 1
-        yden = Bp * xp + 1
+        xnum = X
+        xden = Y
+        ynum = invSqrtD * X - 1
+        yden = invSqrtD * X + 1
         if xden * yden == 0:
             return (0, 1)
         return (xnum / xden, ynum / yden)
 
-    def nsl_map_inv(self, x, y):
-        Bp = self.Bp
-        xnum = ynum = 1 + y
-        xden = Bp * (1 - y)
-        yden = xden * x
+    def nsl_map_inv(self, v, w):
+        invSqrtD = self.Bp
+
+        xnum = ynum = 1 + w
+        xden = invSqrtD * (1 - w)
+        yden = xden * v
         if xden * yden == 0:
             return (0, 0)
         return (xnum / xden, ynum / yden)
@@ -62,19 +63,19 @@ class GenericEll2Edw(GenericMap):
         (xp, yp) = self.ell2_map.straight_line(u)
         return self.sl_map(xp, yp)
 
-    def sl_map(self, x, y):
-        Bp = self.Bp
+    def sl_map(self, X, Y):
+        invSqrtD = self.Bp
         inv0 = self.inv0
 
-        t1 = x * Bp
-        t2 = t1 + 1
-        t3 = y * t2
-        t3 = inv0(t3)
-        v = t2 * t3
-        v = v * x
-        w = t1 - 1
-        w = w * y
-        w = w * t3
+        tv1 = X * invSqrtD
+        tv2 = tv1 + 1
+        tv3 = Y * tv2
+        tv3 = inv0(tv3)
+        v = tv2 * tv3
+        v = v * X
+        w = tv1 - 1
+        w = w * Y
+        w = w * tv3
         e = w == 0
         w = CMOV(w, 1, e)
         return (v, w)

--- a/poc/map_check.sage
+++ b/poc/map_check.sage
@@ -34,9 +34,9 @@ def check_edwards():
 # https://eprint.iacr.org/2008/013
 
 # Montgomery curve equation
-Rm.<V,W,J,K> = QQ[]
-Monty = lambda V, W, J, K: K * W^2 - (V^3 + J * V^2 + V)
-MC = Rm.quotient(Monty(V, W, J, K))
+Rm.<s,t,J,K> = QQ[]
+Monty = lambda s, t, J, K: K * t^2 - (s^3 + J * s^2 + s)
+MC = Rm.quotient(Monty(s, t, J, K))
 
 # Short Weierstrass curve equation
 Rw.<x,y,A,B> = QQ[]
@@ -56,16 +56,16 @@ TEC = Re.quotient(Edw(v, w, a, d))
 def check_m2aw():
     C = J / K
     sqrtD = 1 / K
-    X = V / K
-    Y = W / K
+    X = s / K
+    Y = t / K
     assert 0 == MC(LWeier(X, Y, C, sqrtD).numerator())
 
 def check_aw2m():
     J = C / sqrtD
     K = 1 / sqrtD
-    V = X / sqrtD
-    W = Y / sqrtD
-    assert 0 == LWC(Monty(V, W, J, K).numerator())
+    s = X / sqrtD
+    t = Y / sqrtD
+    assert 0 == LWC(Monty(s, t, J, K).numerator())
 
 def check_e2aw():
     C = (a + d) / 2
@@ -84,22 +84,22 @@ def check_aw2e():
 def check_e2m():
     J = 2 * (a + d) / (a - d)
     K = 4 / (a - d)
-    V = (1 + w) / (1 - w)
-    W = (1 + w) / (v * (1 - w))
-    assert 0 == TEC(Monty(V, W, J, K).numerator())
+    s = (1 + w) / (1 - w)
+    t = (1 + w) / (v * (1 - w))
+    assert 0 == TEC(Monty(s, t, J, K).numerator())
 
 def check_m2e():
     a = (J + 2) / K
     d = (J - 2) / K
-    v = V / W
-    w = (V - 1) / (V + 1)
+    v = s / t
+    w = (s - 1) / (s + 1)
     assert 0 == MC(Edw(v, w, a, d).numerator())
 
 def check_m2w():
     A = (3 - J^2) / (3 * K^2)
     B = (2 * J^3 - 9 * J) / (27 * K^3)
-    x = (3 * V + J) / (3 * K)
-    y = W / K
+    x = (3 * s + J) / (3 * K)
+    y = t / K
     assert 0 == MC(SWeier(x, y, A, B).numerator())
 
 def check_e2w():

--- a/poc/sswu_generic.sage
+++ b/poc/sswu_generic.sage
@@ -41,9 +41,9 @@ class GenericSSWU(GenericMap):
         B = self.B
         Z = self.Z
 
-        t1 = inv0(Z^2 * u^4 + Z * u^2)
-        x1 = (-B / A) * (1 + t1)
-        if t1 == 0:
+        tv1 = inv0(Z^2 * u^4 + Z * u^2)
+        x1 = (-B / A) * (1 + tv1)
+        if tv1 == 0:
             x1 = B / (Z * A)
         gx1 = x1^3 + A * x1 + B
         x2 = Z * u^2 * x1
@@ -70,26 +70,26 @@ class GenericSSWU(GenericMap):
         c1 = self.c1
         c2 = self.c2
 
-        t1 = Z * u^2
-        t2 = t1^2
-        x1 = t1 + t2
+        tv1 = Z * u^2
+        tv2 = tv1^2
+        x1 = tv1 + tv2
         x1 = inv0(x1)
         e1 = x1 == 0
         x1 = x1 + 1
-        x1 = CMOV(x1, c2, e1)           #// If (t1 + t2) == 0, set x1 = -1 / Z
-        x1 = x1 * c1                    #// x1 = (-B / A) * (1 + (1 / (Z^2 * u^4 + Z * u^2)))
+        x1 = CMOV(x1, c2, e1)    # If (tv1 + tv2) == 0, set x1 = -1 / Z
+        x1 = x1 * c1      # x1 = (-B / A) * (1 + (1 / (Z^2 * u^4 + Z * u^2)))
         gx1 = x1^2
         gx1 = gx1 + A
         gx1 = gx1 * x1
-        gx1 = gx1 + B                   #// gx1 = g(x1) = x1^3 + A * x1 + B
-        x2 = t1 * x1                    #// x2 = Z * u^2 * x1
-        t2 = t1 * t2
-        gx2 = gx1 * t2                  #// gx2 = (Z * u^2)^3 * gx1
+        gx1 = gx1 + B             # gx1 = g(x1) = x1^3 + A * x1 + B
+        x2 = tv1 * x1            # x2 = Z * u^2 * x1
+        tv2 = tv1 * tv2
+        gx2 = gx1 * tv2           # gx2 = (Z * u^2)^3 * gx1
         e2 = is_square(gx1)
-        x = CMOV(x2, x1, e2)            #// If is_square(gx1), x = x1, else x = x2
-        y2 = CMOV(gx2, gx1, e2)         #// If is_square(gx1), y2 = gx1, else y2 = gx2
+        x = CMOV(x2, x1, e2)    # If is_square(gx1), x = x1, else x = x2
+        y2 = CMOV(gx2, gx1, e2)  # If is_square(gx1), y2 = gx1, else y2 = gx2
         y = sqrt(y2)
-        e3 = sgn0(u) == sgn0(y)         #// Fix sign of y
+        e3 = sgn0(u) == sgn0(y)  # Fix sign of y
         y = CMOV(-y, y, e3)
         return (x, y)
 

--- a/poc/sswu_opt.sage
+++ b/poc/sswu_opt.sage
@@ -38,38 +38,38 @@ class OptimizedSSWU(object):
         c2 = self.c2
         u = F(u)
 
-        t1 = u^2
-        t3 = Z * t1
-        t2 = t3^2
-        xd = t2 + t3
+        tv1 = u^2
+        tv3 = Z * tv1
+        tv2 = tv3^2
+        xd = tv2 + tv3
         x1n = xd + 1
         x1n = x1n * B
         xd = -A * xd
         e1 = xd == 0
-        xd = CMOV(xd, Z * A, e1)    # If xd == 0, set xd = Z * A
-        t2 = xd^2
-        gxd = t2 * xd               # gxd == xd^3
-        t2 = A * t2
+        xd = CMOV(xd, Z * A, e1)  # If xd == 0, set xd = Z * A
+        tv2 = xd^2
+        gxd = tv2 * xd             # gxd == xd^3
+        tv2 = A * tv2
         gx1 = x1n^2
-        gx1 = gx1 + t2              # x1n^2 + A * xd^2
-        gx1 = gx1 * x1n             # x1n^3 + A * x1n * xd^2
-        t2 = B * gxd
-        gx1 = gx1 + t2              # x1n^3 + A * x1n * xd^2 + B * xd^3
-        t4 = gxd^2
-        t2 = gx1 * gxd
-        t4 = t4 * t2                # gx1 * gxd^3
-        y1 = t4^c1                  # (gx1 * gxd^3)^((p - 3) / 4)
-        y1 = y1 * t2                # gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
-        x2n = t3 * x1n              # x2 = x2n / xd = -10 * u^2 * x1n / xd
-        y2 = y1 * c2                # y2 = y1 * sqrt(-Z^3)
-        y2 = y2 * t1
+        gx1 = gx1 + tv2            # x1n^2 + A * xd^2
+        gx1 = gx1 * x1n            # x1n^3 + A * x1n * xd^2
+        tv2 = B * gxd
+        gx1 = gx1 + tv2            # x1n^3 + A * x1n * xd^2 + B * xd^3
+        tv4 = gxd^2
+        tv2 = gx1 * gxd
+        tv4 = tv4 * tv2            # gx1 * gxd^3
+        y1 = tv4^c1               # (gx1 * gxd^3)^((p - 3) / 4)
+        y1 = y1 * tv2             # gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
+        x2n = tv3 * x1n            # x2 = x2n / xd = -10 * u^2 * x1n / xd
+        y2 = y1 * c2              # y2 = y1 * sqrt(-Z^3)
+        y2 = y2 * tv1
         y2 = y2 * u
-        t2 = y1^2
-        t2 = t2 * gxd
-        e2 = t2 == gx1
-        xn = CMOV(x2n, x1n, e2)     # If e2, x = x1, else x = x2
-        y = CMOV(y2, y1, e2)        # If e2, y = y1, else y = y2
-        e3 = sgn0(u) == sgn0(y)     # Fix sign of y
+        tv2 = y1^2
+        tv2 = tv2 * gxd
+        e2 = tv2 == gx1
+        xn = CMOV(x2n, x1n, e2)   # If e2, x = x1, else x = x2
+        y = CMOV(y2, y1, e2)     # If e2, y = y1, else y = y2
+        e3 = sgn0(u) == sgn0(y)   # Fix sign of y
         y = CMOV(-y, y, e3)
         return (xn, xd, y, 1)
 

--- a/poc/svdw_generic.sage
+++ b/poc/svdw_generic.sage
@@ -53,41 +53,41 @@ class GenericSvdW(GenericMap):
         B = self.B
         Z = self.Z
 
-        t1 = u^2
-        t1 = t1 * c1
-        t2 = 1 + t1
-        t1 = 1 - t1
-        t3 = t1 * t2
-        t3 = inv0(t3)
-        t4 = u * t1
-        t4 = t4 * t3
-        t4 = t4 * c3
-        x1 = c2 - t4
+        tv1 = u^2
+        tv1 = tv1 * c1
+        tv2 = 1 + tv1
+        tv1 = 1 - tv1
+        tv3 = tv1 * tv2
+        tv3 = inv0(tv3)
+        tv4 = u * tv1
+        tv4 = tv4 * tv3
+        tv4 = tv4 * c3
+        x1 = c2 - tv4
         gx1 = x1^2
         gx1 = gx1 + A
         gx1 = gx1 * x1
         gx1 = gx1 + B
         e1 = is_square(gx1)
-        x2 = c2 + t4
+        x2 = c2 + tv4
         gx2 = x2^2
         gx2 = gx2 + A
         gx2 = gx2 * x2
         gx2 = gx2 + B
-        e2 = is_square(gx2) and not e1     #// avoid short-circuit logic ops
-        x3 = t2^2
-        x3 = x3 * t3
+        e2 = is_square(gx2) and not e1     # Avoid short-circuit logic ops
+        x3 = tv2^2
+        x3 = x3 * tv3
         x3 = x3^2
         x3 = x3 * c4
         x3 = x3 + Z
-        x = CMOV(x3, x1, e1)      #// x = x1 if gx1 is square, else x = x3
-        x = CMOV(x, x2, e2)       #// x = x2 if gx2 is square and gx1 is not
+        x = CMOV(x3, x1, e1)      # x = x1 if gx1 is square, else x = x3
+        x = CMOV(x, x2, e2)       # x = x2 if gx2 is square and gx1 is not
         gx = x^2
         gx = gx + A
         gx = gx * x
         gx = gx + B
         y = sqrt(gx)
         e3 = sgn0(u) == sgn0(y)
-        y = CMOV(-y, y, e3)       #// select correct sign of y
+        y = CMOV(-y, y, e3)       # Select correct sign of y
         return (x, y)
 
     def not_straight_line(self, u):
@@ -100,16 +100,16 @@ class GenericSvdW(GenericMap):
         sqrt = self.sqrt
         u = self.F(u)
 
-        t1 = u^2 * g(Z)
-        t2 = 1 + t1
-        t1 = 1 - t1
-        t3 = inv0(t1 * t2)
-        t4 = sqrt(-g(Z) * (3 * Z^2 + 4 * A))
-        t4 = t4 * sgn0(t4)                          #// sgn0(t4) == 1
-        t5 = u * t1 * t3 * t4
-        x1 = -Z / 2 - t5
-        x2 = -Z / 2 + t5
-        x3 = Z - 4 * g(Z) * (t2^2 * t3)^2 / (3 * Z^2 + 4 * A)
+        tv1 = u^2 * g(Z)
+        tv2 = 1 + tv1
+        tv1 = 1 - tv1
+        tv3 = inv0(tv1 * tv2)
+        tv4 = sqrt(-g(Z) * (3 * Z^2 + 4 * A))
+        tv4 = tv4 * sgn0(tv4)                    # sgn0(tv4) MUST equal 1
+        tv5 = u * tv1 * tv3 * tv4
+        x1 = -Z / 2 - tv5
+        x2 = -Z / 2 + tv5
+        x3 = Z - 4 * g(Z) * (tv2^2 * tv3)^2 / (3 * Z^2 + 4 * A)
         if is_square(g(x1)):
             x = x1
             y = sqrt(g(x1))

--- a/poc/test.sage
+++ b/poc/test.sage
@@ -9,7 +9,7 @@ try:
     from sagelib.bf_generic import GenericBF
     from sagelib.common import test_ts
     from sagelib.ell2_generic import GenericEll2
-    from sagelib.ell2a0_generic import GenericEll2A0
+    from sagelib.ell2c0_generic import GenericEll2C0
     from sagelib.ell2edw_generic import GenericEll2Edw
     from sagelib.sswu_generic import GenericSSWU
     from sagelib.svdw_generic import GenericSvdW
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     test_sswu()
 
     print "Testing generic maps"
-    for m in (GenericBF, GenericEll2, GenericEll2A0, GenericEll2Edw, GenericSSWU, GenericSvdW):
+    for m in (GenericBF, GenericEll2, GenericEll2C0, GenericEll2Edw, GenericSSWU, GenericSvdW):
         print "Testing %s" % m.__name__
         for _ in range(0, 32):
             m.test_random()


### PR DESCRIPTION
This PR fixes and clarifies a few things:

- resolves ambiguity in sign of a sqrt in SvdW high-level procedural description

- remove pairing-friendly draft cite (we can't go to last call with an I-D ref per Nick)

- update variable names in elliptic curve equations (again, this time I think is better) and make corresponding changes in `map_check.sage`

- clean up unused stuff: abs(x) is not used, one of the constants in the optimized sswu impl is not used

- notational consistency throughout

- slightly improved discussion of indifferentiability

- other minor touch-up issues

See next post for discussion of notation