### PR TITLE
Add appendix section for `clear_cofactor` in BLS12-381 G2.

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2792,7 +2792,7 @@ except that the encoding type is encode\_to\_curve ({{roadmap}}).
 
 Note that the h\_eff values for these suites are chosen for compatibility
 with the fast cofactor clearing method described by
-Budroni and Pintore ({{BP17}}, Section 4.1).
+Budroni and Pintore ({{BP17}}, Section 4.1), and summarized in {{clear-cofactor-bls12381-g2}}.
 
 ## Defining a new hash-to-curve suite {#new-suite}
 
@@ -3367,6 +3367,62 @@ The constants used to compute y\_den are as follows:
 - k\_(4,0) = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb + 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa8fb * I
 - k\_(4,1) = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffa9d3 * I
 - k\_(4,2) = 0x12 + 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaa99 * I
+
+# Cofactor Clearing {#clear-cofactor-suites}
+
+Some elliptic curve groups, e.g. G2 in BLS12-381, have a very large cofactor h\_eff (cf. {{cofactor-clearing}}).
+For these curves, we propose an alternative method for clearing the cofactor.
+
+## Cofactor Clearing on E' for BLS12-381 {#clear-cofactor-bls12381-g2}
+
+This fast cofactor clearing function was introduced by Budroni and Pintore {{BP18}}.
+It is based on Fuentes et al.'s method {{FKR11}}, and makes use of an efficiently-computable
+curve endomorphism `psi`.
+For the pairing-friendly curve BLS12-381, defined by the following constants {{draft-yonezawa-pfc-01}}:
+
+~~~
+p = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+x = -0xd201000000010000
+
+Zp = GF(p)
+Zp2.<i> = GF(p^2, modulus=[1, 0, 1])
+u = i+1
+
+E2 = EllipticCurve(Zp2, [0, 4*u])
+E1 = EllipticCurve(Zp, [0, 4])
+~~~
+
+the mapping `psi` can be expressed in jacobian (and homogeneous) projective coordinates as:
+
+~~~
+def psi(P):
+    P_x, P_y, P_z = P
+    return E2(P_x.frobenius()/(u^((p-1)/3)), P_y.frobenius()/u^((p-1)/2), P_z.frobenius())
+
+def psi2(P):
+    # return psi(psi(P))
+    P_x, P_y, P_z = P
+    return E2(P_x.frobenius(2)/Zp(2)^((p-1)/3), -P_y.frobenius(2), P_z)
+~~~
+
+Note that constants in the multiplication can be pre-processed.
+In affine coordinates, one can just ignore the computations on `P_z`.
+The cofactor clearing function, mapping points from E' to G2, is:
+
+~~~
+def clear_cofactor_bls12381_g2(P):
+    # h_eff = 3 * (x^2 - 1) * (E2.order() // r)
+    # return h_eff * P
+    t1 = x * P
+    t2 = psi(P)
+    return (psi2(2 * P)    # psi(psi(P))
+            + x*(t1 + t2)  # psi(psi(P)) + x psi(P) + x^2 P
+            - t1           # psi(psi(P)) + x psi(P) + (x^2-x) P +
+            - t2           # psi(psi(P)) + (x-1) psi(P) + (x^2-x) P
+            - P)           # psi(psi(P)) + (x-1) psi(P) + (x^2-x-1) P
+~~~
+
 
 # Sample Code {#samplecode}
 


### PR DESCRIPTION
This pull request fixes #166 specifying the algorithm of [BP18] for a fast cofactor clearing.