### PR TITLE
Generation of test vectors

### DIFF
--- a/poc/Makefile
+++ b/poc/Makefile
@@ -17,5 +17,12 @@ sagelib/%.py: %.sage
 	@sage --preparse $<
 	@mv $<.py $@
 
+test: pyfiles
+	sage test.sage
+
+vectors: pyfiles
+	@mkdir -p vectors
+	sage test_vectors.sage
+
 clean:
-	rm -rf sagelib *.pyc *.sage.py *.log
+	rm -rf sagelib *.pyc *.sage.py *.log vectors

--- a/poc/Makefile
+++ b/poc/Makefile
@@ -21,8 +21,8 @@ test: pyfiles
 	sage test.sage
 
 vectors: pyfiles
-	@mkdir -p vectors
+	@mkdir -p vectors ascii
 	sage test_vectors.sage
 
 clean:
-	rm -rf sagelib *.pyc *.sage.py *.log vectors
+	rm -rf sagelib *.pyc *.sage.py *.log vectors ascii

--- a/poc/README.md
+++ b/poc/README.md
@@ -5,7 +5,7 @@ In addition, you'll need a reasonably modern version of make (GNU make works wel
 
 ## Getting started
 
-1. `make` --- This preprocesses the sage files. If you don't do this, you'll get
+1. `make -j` --- This preprocesses the sage files. If you don't do this, you'll get
    an error message telling you to do it.
 
 2. `make test` --- runs all tests. This takes several minutes.

--- a/poc/README.md
+++ b/poc/README.md
@@ -5,7 +5,7 @@ In addition, you'll need a reasonably modern version of make (GNU make works wel
 
 ## Getting started
 
-1. `make -j` --- This preprocesses the sage files. If you don't do this, you'll get
+1. `make` --- This preprocesses the sage files. If you don't do this, you'll get
    an error message telling you to do it.
 
 2. `make test` --- runs all tests. This takes several minutes.

--- a/poc/README.md
+++ b/poc/README.md
@@ -8,10 +8,12 @@ In addition, you'll need a reasonably modern version of make (GNU make works wel
 1. `make` --- This preprocesses the sage files. If you don't do this, you'll get
    an error message telling you to do it.
 
-2. `sage test.sage` --- runs all tests. This takes several minutes.
+2. `make test` --- runs all tests. This takes several minutes.
 
 3. Alternatively, most files will self-test if executed with sage, e.g.,
    `sage suite_p256.sage`.
+
+4. `make vectors` --- generates all test vectors.
 
 # In more detail
 

--- a/poc/curves.sage
+++ b/poc/curves.sage
@@ -27,9 +27,15 @@ class PointBase(object):
     def __repr__(self):
         return "(%d : %d : %d)" % (self.x, self.y, self.z)
 
+    def curve(self):
+        return self.E
+
 class CurveBase(object):
     def __call__(self, x, y, z=1):
         return self.PointT(self, x, y, z)
+
+    def base_field(self):
+        return self.F
 
     def order(self):
         return self.E.order()

--- a/poc/ell2_generic.sage
+++ b/poc/ell2_generic.sage
@@ -11,6 +11,7 @@ except ImportError:
 
 class GenericEll2(GenericMap):
     def __init__(self, F, A, B):
+        self.name = "Elligator2"
         self.F = F
         A = F(A)
         B = F(B)

--- a/poc/ell2_generic.sage
+++ b/poc/ell2_generic.sage
@@ -11,7 +11,7 @@ except ImportError:
 
 class GenericEll2(GenericMap):
     def __init__(self, F, A, B):
-        self.name = "Elligator2"
+        self.name = "ELL2"
         self.F = F
         A = F(A)
         B = F(B)

--- a/poc/generic_map.sage
+++ b/poc/generic_map.sage
@@ -14,6 +14,13 @@ class GenericMap(object):
     not_straight_line = None
     sgn0 = staticmethod(sgn0_le)
     sqrt = staticmethod(square_root)
+    name = None
+
+    def __dict__(self):
+        return {
+            "name" :  self.name,
+            "sgn0": "sgn0_le" if self.sgn0 == sgn0_le else "sgn0_be",
+        }
 
     def set_sgn0(self, fn):
         self.sgn0 = fn

--- a/poc/h2c_suite.sage
+++ b/poc/h2c_suite.sage
@@ -12,16 +12,18 @@ try:
 except ImportError:
     sys.exit("Error loading preprocessed sage files. Try running `make clean pyfiles`")
 
-BasicH2CSuiteDef = namedtuple("BasicH2CSuiteDef", "F Aa Bd sgn0 H L MapT h_eff is_ro dst")
+BasicH2CSuiteDef = namedtuple("BasicH2CSuiteDef", "E F Aa Bd sgn0 H L MapT h_eff is_ro dst")
 IsoH2CSuiteDef = namedtuple("IsoH2CSuiteDef", "base Ap Bp iso_map")
 EdwH2CSuiteDef = namedtuple("EdwH2CSuiteDef", "base Ap Bp rational_map")
 
 class BasicH2CSuite(object):
-    def __init__(self, sdef):
+    def __init__(self, name, sdef):
         assert isinstance(sdef, BasicH2CSuiteDef)
 
         # basics: details of the base field
         F = sdef.F
+        self.suite_name = name
+        self.curve_name = sdef.E
         self.F = F
         self.p = F.characteristic()
         self.m = F.degree()
@@ -39,6 +41,20 @@ class BasicH2CSuite(object):
         self.h_eff = sdef.h_eff
         self.is_ro = sdef.is_ro
         self.dst = sdef.dst
+
+    def __dict__(self):
+        return {
+            "ciphersuite": self.suite_name,
+            "field":{
+                "p" :  '0x{0}'.format(ZZ(self.p).hex()),
+                "m" :  '0x{0}'.format(ZZ(self.m).hex()),
+            },
+            "curve": self.curve_name,
+            "dst": self.dst,
+            "hash": (self.H()).name,
+            "map": self.m2c.__dict__(),
+            "randomOracle": bool(self.is_ro),
+        }
 
     @staticmethod
     def to_self(x):
@@ -118,10 +134,10 @@ class BasicH2CSuite(object):
         return self._hash_to_curve(msg, self.hash_to_base, self.map_to_curve, self.clear_cofactor)
 
 class IsoH2CSuite(BasicH2CSuite):
-    def __init__(self, sdef):
+    def __init__(self, name, sdef):
         assert isinstance(sdef, IsoH2CSuiteDef)
         assert isinstance(sdef.base, BasicH2CSuiteDef)
-        super(IsoH2CSuite, self).__init__(sdef.base._replace(Aa=sdef.Ap, Bd=sdef.Bp))
+        super(IsoH2CSuite, self).__init__(name, sdef.base._replace(Aa=sdef.Ap, Bd=sdef.Bp))
 
         # check that we got a reasonable isogeny map
         self.iso_map = sdef.iso_map
@@ -130,7 +146,7 @@ class IsoH2CSuite(BasicH2CSuite):
         self.to_self = self.iso_map
 
 class MontyH2CSuite(BasicH2CSuite):
-    def __init__(self, sdef):
+    def __init__(self, name, sdef):
         assert isinstance(sdef, BasicH2CSuiteDef)
 
         # figure out mapping to required Weierstrass form and init base class
@@ -140,16 +156,16 @@ class MontyH2CSuite(BasicH2CSuite):
         A = Ap / Bp
         B = 1 / Bp^2
         self.Bp = Bp
-        super(MontyH2CSuite, self).__init__(sdef._replace(Aa=A, Bd=B, MapT=GenericEll2))
+        super(MontyH2CSuite, self).__init__(name, sdef._replace(Aa=A, Bd=B, MapT=GenericEll2))
 
         # helper: do point ops directly on the Monty repr
         self.monty = MontgomeryCurve(F, Ap, Bp)
         self.to_self = self.monty.to_self
 
 class EdwH2CSuite(MontyH2CSuite):
-    def __init__(self, sdef):
+    def __init__(self, name, sdef):
         assert isinstance(sdef, EdwH2CSuiteDef)
-        super(EdwH2CSuite, self).__init__(sdef.base._replace(Aa=sdef.Ap, Bd=sdef.Bp))
+        super(EdwH2CSuite, self).__init__(name, sdef.base._replace(Aa=sdef.Ap, Bd=sdef.Bp))
 
         # helper: do 'native' point ops directly on the Edwards repr
         self.edwards = EdwardsCurve(sdef.base.F, sdef.base.Aa, sdef.base.Bd)

--- a/poc/printer.py
+++ b/poc/printer.py
@@ -1,0 +1,72 @@
+#!/usr/bin/sage
+# vim: syntax=python
+
+import textwrap
+
+from hash_to_base import I2OSP
+
+
+class Printer:
+    """ Prints values in rfc format """
+
+    @staticmethod
+    def _pprint_hex(octet_string):
+        return "".join("{:02x}".format(ord(c)) for c in octet_string)
+
+    @staticmethod
+    def _tv_wrap(text):
+        return textwrap.fill(text, 54).split("\n")
+
+    @staticmethod
+    def _lv(label, values):
+        prefix = "%7s = " % label
+        sep_lines = "\n" + " " * 10
+        sep_extension = "\n" + " " * 7 + "+i*"
+        out = sep_extension.join([sep_lines.join(Printer._tv_wrap(value))
+                                  for value in values])
+        return prefix + out
+
+    @staticmethod
+    def _gf_hex(num, length):
+        return [Printer._pprint_hex(I2OSP(ni, length)) for ni in list(num.polynomial())]
+
+    @staticmethod
+    def _get_length(point):
+        curve = point.curve()
+        field = curve.base_field()
+        prime = field.characteristic()
+        return len(prime.digits(2**8))
+
+    class tv:
+        @staticmethod
+        def text(label, value):
+            """ Prints a string message """
+            return Printer._lv(label, [value])
+
+        @staticmethod
+        def value(label, value, length):
+            """ Prints a value """
+            return Printer._lv(label, Printer._gf_hex(value, length))
+
+        @staticmethod
+        def point(point):
+            if point.is_zero():
+                return "inf"
+            x, y, z = point
+            length = Printer._get_length(point)
+            return "\n".join([
+                Printer.tv.value("x", x, length),
+                Printer.tv.value("y", y, length)])
+
+    class math:
+        @staticmethod
+        def gf(num, length):
+            return ",".join(["0x{0}".format(numi) for numi in Printer._gf_hex(num, length)])
+
+        @staticmethod
+        def point(point):
+            if point.is_zero():
+                return {"inf": True}
+            x, y, z = point
+            length = Printer._get_length(point)
+            return {"x": Printer.math.gf(x, length), "y": Printer.math.gf(y, length)}

--- a/poc/printer.py
+++ b/poc/printer.py
@@ -11,7 +11,10 @@ class Printer:
 
     @staticmethod
     def _pprint_hex(octet_string):
-        return "".join("{:02x}".format(ord(c)) for c in octet_string)
+        if type(octet_string) == str:
+            return "".join("{:02x}".format(ord(c)) for c in octet_string)
+        if type(octet_string) == bytes:
+            return "".join("{:02x}".format(c) for c in octet_string)
 
     @staticmethod
     def _tv_wrap(text):
@@ -19,7 +22,7 @@ class Printer:
 
     @staticmethod
     def _lv(label, values):
-        prefix = "%7s = " % label
+        prefix = "{:7s} = ".format(label)
         sep_lines = "\n" + " " * 10
         sep_extension = "\n" + " " * 7 + "+i*"
         out = sep_extension.join([sep_lines.join(Printer._tv_wrap(value))

--- a/poc/sswu_generic.sage
+++ b/poc/sswu_generic.sage
@@ -11,6 +11,7 @@ except ImportError:
 
 class GenericSSWU(GenericMap):
     def __init__(self, F, A, B):
+        self.name = "SSWU"
         self.F = F
         self.A = F(A)
         self.B = F(B)

--- a/poc/suite_25519.sage
+++ b/poc/suite_25519.sage
@@ -40,12 +40,19 @@ def m2e_25519(P):
 
 monty_suite = BasicH2CSuiteDef("curve25519", F, Ap, Bp, sgn0_le, hashlib.sha256, 48, None, 8, True, DST)
 edw_suite = EdwH2CSuiteDef(monty_suite._replace(E="edwards25519",Aa=a, Bd=d), Ap, Bp, m2e_25519)
-edw25519_hash_ro = EdwH2CSuite("edwards25519-SHA256-EDELL2-RO-",edw_suite)
-monty25519_hash_ro = MontyH2CSuite("curve25519-SHA256-ELL2-RO-",monty_suite)
-edw25519_hash_nu = EdwH2CSuite("edwards25519-SHA256-EDELL2-NU-",edw_suite._replace(base=edw_suite.base._replace(is_ro=False)))
-monty25519_hash_nu = MontyH2CSuite("curve25519-SHA256-ELL2-NU-",monty_suite._replace(is_ro=False))
-assert edw25519_hash_ro.m2c.Z == edw25519_hash_nu.m2c.Z == 2
-assert monty25519_hash_ro.m2c.Z == monty25519_hash_nu.m2c.Z == 2
+edw25519_sha256_ro = EdwH2CSuite("edwards25519-SHA256-EDELL2-RO-",edw_suite)
+monty25519_sha256_ro = MontyH2CSuite("curve25519-SHA256-ELL2-RO-",monty_suite)
+edw25519_sha256_nu = EdwH2CSuite("edwards25519-SHA256-EDELL2-NU-",edw_suite._replace(base=edw_suite.base._replace(is_ro=False)))
+monty25519_sha256_nu = MontyH2CSuite("curve25519-SHA256-ELL2-NU-",monty_suite._replace(is_ro=False))
+
+edw25519_sha512_ro = EdwH2CSuite("edwards25519-SHA512-EDELL2-RO-",edw_suite._replace(base=edw_suite.base._replace(H=hashlib.sha512)))
+monty25519_sha512_ro = MontyH2CSuite("curve25519-SHA512-ELL2-RO-",monty_suite._replace(H=hashlib.sha512))
+edw25519_sha512_nu = EdwH2CSuite("edwards25519-SHA512-EDELL2-NU-",edw_suite._replace(base=edw_suite.base._replace(H=hashlib.sha512,is_ro=False)))
+monty25519_sha512_nu = MontyH2CSuite("curve25519-SHA512-ELL2-NU-",monty_suite._replace(H=hashlib.sha512,is_ro=False))
+assert edw25519_sha256_ro.m2c.Z == edw25519_sha256_nu.m2c.Z == 2
+assert monty25519_sha256_ro.m2c.Z == monty25519_sha256_nu.m2c.Z == 2
+assert edw25519_sha512_ro.m2c.Z == edw25519_sha512_nu.m2c.Z == 2
+assert monty25519_sha512_ro.m2c.Z == monty25519_sha512_nu.m2c.Z == 2
 
 group_order = 2^252 + 0x14def9dea2f79cd65812631a5cf5d3ed
 
@@ -63,8 +70,10 @@ def _test_suite(edw_hash, monty_hash, m2e, group_order, nreps=128):
     assert (monty_out * group_order).is_zero()
 
 def test_suite_25519():
-    _test_suite(edw25519_hash_ro, monty25519_hash_ro, m2e_25519, group_order)
-    _test_suite(edw25519_hash_nu, monty25519_hash_nu, m2e_25519, group_order)
+    _test_suite(edw25519_sha256_ro, monty25519_sha256_ro, m2e_25519, group_order)
+    _test_suite(edw25519_sha256_nu, monty25519_sha256_nu, m2e_25519, group_order)
+    _test_suite(edw25519_sha512_ro, monty25519_sha512_ro, m2e_25519, group_order)
+    _test_suite(edw25519_sha512_nu, monty25519_sha512_nu, m2e_25519, group_order)
 
 if __name__ == "__main__":
     test_suite_25519()

--- a/poc/suite_448.sage
+++ b/poc/suite_448.sage
@@ -6,6 +6,7 @@ import sys
 try:
     from sagelib.common import sgn0_le
     from sagelib.h2c_suite import BasicH2CSuiteDef, EdwH2CSuiteDef, EdwH2CSuite, MontyH2CSuite
+    from sagelib.suite_25519 import _test_suite
 except ImportError:
     sys.exit("Error loading preprocessed sage files. Try running `make clean pyfiles`")
 
@@ -35,28 +36,20 @@ def m2e_448(P):
         return (0, 1, 0)
     return (xn / xd, yn / yd, 1)
 
-monty_suite = BasicH2CSuiteDef(F, Ap, Bp, sgn0_le, hashlib.sha512, 84, None, 4, True, DST)
-edw_suite = EdwH2CSuiteDef(monty_suite._replace(Aa=a, Bd=d), Ap, Bp, m2e_448)
-edw_hash = EdwH2CSuite(edw_suite)
-monty_hash = MontyH2CSuite(monty_suite)
-assert edw_hash.m2c.Z == -1
-assert monty_hash.m2c.Z == -1
+monty_suite = BasicH2CSuiteDef("curve448", F, Ap, Bp, sgn0_le, hashlib.sha512, 84, None, 4, True, DST)
+edw_suite = EdwH2CSuiteDef(monty_suite._replace(E="edwards448",Aa=a, Bd=d), Ap, Bp, m2e_448)
+edw448_hash_ro = EdwH2CSuite("edwards448-SHA512-EDELL2-RO-",edw_suite)
+monty448_hash_ro = MontyH2CSuite("curve448-SHA512-ELL2-RO-",monty_suite)
+edw448_hash_nu = EdwH2CSuite("edwards448-SHA512-EDELL2-NU-",edw_suite._replace(base=edw_suite.base._replace(is_ro=False)))
+monty448_hash_nu = MontyH2CSuite("curve448-SHA512-ELL2-NU-",monty_suite._replace(is_ro=False))
+assert edw448_hash_ro.m2c.Z == edw448_hash_nu.m2c.Z == -1
+assert monty448_hash_ro.m2c.Z == monty448_hash_nu.m2c.Z == -1
 
 group_order = 2^446 - 0x8335dc163bb124b65129c96fde933d8d723a70aadc873d6d54a7bb0d
 
 def test_suite_448():
-    accumE = edw_hash('asdf')
-    accumM = monty_hash('asdf')
-    for _ in range(0, 128):
-        msg = ''.join( chr(randrange(32, 126)) for _ in range(0, 32) )
-        edw_out = edw_hash(msg)
-        monty_out = monty_hash(msg)
-        assert tuple(edw_out) == m2e_448(monty_out)
-        assert (edw_out * group_order).is_zero()
-        accumE += edw_out
-        accumM += monty_out
-    assert (edw_out * group_order).is_zero()
-    assert (monty_out * group_order).is_zero()
+    _test_suite(edw448_hash_ro, monty448_hash_ro, m2e_448, group_order)
+    _test_suite(edw448_hash_nu, monty448_hash_nu, m2e_448, group_order)
 
 if __name__ == "__main__":
     test_suite_448()

--- a/poc/suite_bls12381g1.sage
+++ b/poc/suite_bls12381g1.sage
@@ -24,18 +24,22 @@ Bp = F(0x12e2908d11688030018b12e8753eee3b2016c1f0f24f4070a0b9c14fcef35ef55a23215
 h_eff = 0xd201000000010001
 iso_map = iso_bls12381g1()
 
-bls12381g1_svdw_def = BasicH2CSuiteDef(F, A, B, sgn0_be, hashlib.sha256, 64, GenericSvdW, h_eff, True, DST)
+bls12381g1_svdw_def = BasicH2CSuiteDef("BLS12381G1", F, A, B, sgn0_be, hashlib.sha256, 64, GenericSvdW, h_eff, True, DST)
 bls12381g1_sswu_def = IsoH2CSuiteDef(bls12381g1_svdw_def._replace(MapT=GenericSSWU), Ap, Bp, iso_map)
-bls12381g1_svdw = BasicH2CSuite(bls12381g1_svdw_def)
-bls12381g1_sswu = IsoH2CSuite(bls12381g1_sswu_def)
-assert bls12381g1_sswu.m2c.Z == 11
-assert bls12381g1_svdw.m2c.Z == -3
+bls12381g1_svdw_ro = BasicH2CSuite("BLS12381G1-SHA256-SVDW-RO-",bls12381g1_svdw_def)
+bls12381g1_sswu_ro = IsoH2CSuite("BLS12381G1-SHA256-SSWU-RO-",bls12381g1_sswu_def)
+bls12381g1_svdw_nu = BasicH2CSuite("BLS12381G1-SHA256-SVDW-NU-",bls12381g1_svdw_def._replace(is_ro=False))
+bls12381g1_sswu_nu = IsoH2CSuite("BLS12381G1-SHA256-SSWU-NU-",bls12381g1_sswu_def._replace(base=bls12381g1_sswu_def.base._replace(is_ro=False)))
+assert bls12381g1_sswu_ro.m2c.Z == bls12381g1_sswu_nu.m2c.Z == 11
+assert bls12381g1_svdw_ro.m2c.Z == bls12381g1_svdw_nu.m2c.Z == -3
 
 bls12381g1_order = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
 
 def test_suite_bls12381g1():
-    _test_suite(bls12381g1_sswu, bls12381g1_order)
-    _test_suite(bls12381g1_svdw, bls12381g1_order)
+    _test_suite(bls12381g1_sswu_ro, bls12381g1_order)
+    _test_suite(bls12381g1_svdw_ro, bls12381g1_order)
+    _test_suite(bls12381g1_sswu_nu, bls12381g1_order)
+    _test_suite(bls12381g1_svdw_nu, bls12381g1_order)
 
 if __name__ == "__main__":
     test_suite_bls12381g1()

--- a/poc/suite_bls12381g2.sage
+++ b/poc/suite_bls12381g2.sage
@@ -26,18 +26,22 @@ ell_u = 0xd201000000010000
 h_eff = h2 * (3 * ell_u^2 - 3)
 iso_map = iso_bls12381g2()
 
-bls12381g2_svdw_def = BasicH2CSuiteDef(F, A, B, sgn0_be, hashlib.sha256, 64, GenericSvdW, h_eff, True, DST)
+bls12381g2_svdw_def = BasicH2CSuiteDef("BLS12381G2", F, A, B, sgn0_be, hashlib.sha256, 64, GenericSvdW, h_eff, True, DST)
 bls12381g2_sswu_def = IsoH2CSuiteDef(bls12381g2_svdw_def._replace(MapT=GenericSSWU), Ap, Bp, iso_map)
-bls12381g2_svdw = BasicH2CSuite(bls12381g2_svdw_def)
-bls12381g2_sswu = IsoH2CSuite(bls12381g2_sswu_def)
-assert bls12381g2_sswu.m2c.Z == F(-2 - II)
-assert bls12381g2_svdw.m2c.Z == F(II)
+bls12381g2_svdw_ro = BasicH2CSuite("BLS12381G2-SHA256-SVDW-RO-",bls12381g2_svdw_def)
+bls12381g2_sswu_ro = IsoH2CSuite("BLS12381G2-SHA256-SSWU-RO-",bls12381g2_sswu_def)
+bls12381g2_svdw_nu = BasicH2CSuite("BLS12381G2-SHA256-SVDW-NU-",bls12381g2_svdw_def._replace(is_ro=False))
+bls12381g2_sswu_nu = IsoH2CSuite("BLS12381G2-SHA256-SSWU-NU-",bls12381g2_sswu_def._replace(base=bls12381g2_sswu_def.base._replace(is_ro=False)))
+assert bls12381g2_sswu_ro.m2c.Z == bls12381g2_sswu_nu.m2c.Z == F(-2 - II)
+assert bls12381g2_svdw_ro.m2c.Z == bls12381g2_svdw_nu.m2c.Z == F(II)
 
 bls12381g2_order = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
 
 def test_suite_bls12381g2():
-    _test_suite(bls12381g2_sswu, bls12381g2_order, 8)
-    _test_suite(bls12381g2_svdw, bls12381g2_order, 8)
+    _test_suite(bls12381g2_sswu_ro, bls12381g2_order, 8)
+    _test_suite(bls12381g2_svdw_ro, bls12381g2_order, 8)
+    _test_suite(bls12381g2_sswu_nu, bls12381g2_order, 8)
+    _test_suite(bls12381g2_svdw_nu, bls12381g2_order, 8)
 
 if __name__ == "__main__":
     test_suite_bls12381g2()

--- a/poc/suite_p256.sage
+++ b/poc/suite_p256.sage
@@ -3,7 +3,6 @@
 
 import hashlib
 import sys
-
 try:
     from sagelib.common import sgn0_le
     from sagelib.h2c_suite import BasicH2CSuiteDef, BasicH2CSuite

--- a/poc/suite_p256.sage
+++ b/poc/suite_p256.sage
@@ -3,6 +3,7 @@
 
 import hashlib
 import sys
+
 try:
     from sagelib.common import sgn0_le
     from sagelib.h2c_suite import BasicH2CSuiteDef, BasicH2CSuite
@@ -17,12 +18,14 @@ F = GF(p)
 A = F(-3)
 B = F(0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b)
 
-p256_sswu_def = BasicH2CSuiteDef(F, A, B, sgn0_le, hashlib.sha256, 48, GenericSSWU, 1, True, DST)
+p256_sswu_def = BasicH2CSuiteDef("P256", F, A, B, sgn0_le, hashlib.sha256, 48, GenericSSWU, 1, True, DST)
 p256_svdw_def = p256_sswu_def._replace(MapT=GenericSvdW)
-p256_sswu = BasicH2CSuite(p256_sswu_def)
-p256_svdw = BasicH2CSuite(p256_svdw_def)
-assert p256_sswu.m2c.Z == -10
-assert p256_svdw.m2c.Z == -3
+p256_sswu_ro = BasicH2CSuite("P256-SHA256-SSWU-RO-",p256_sswu_def)
+p256_svdw_ro = BasicH2CSuite("P256-SHA256-SVDW-RO-",p256_svdw_def)
+p256_sswu_nu = BasicH2CSuite("P256-SHA256-SSWU-NU-",p256_sswu_def._replace(is_ro=False))
+p256_svdw_nu = BasicH2CSuite("P256-SHA256-SVDW-NU-",p256_svdw_def._replace(is_ro=False))
+assert p256_sswu_ro.m2c.Z == p256_sswu_nu.m2c.Z == -10
+assert p256_svdw_ro.m2c.Z == p256_svdw_nu.m2c.Z ==  -3
 
 p256_order = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551
 
@@ -34,8 +37,10 @@ def _test_suite(suite, group_order, nreps=128):
     assert (accum * group_order).is_zero()
 
 def test_suite_p256():
-    _test_suite(p256_sswu, p256_order)
-    _test_suite(p256_svdw, p256_order)
+    _test_suite(p256_sswu_ro, p256_order)
+    _test_suite(p256_svdw_ro, p256_order)
+    _test_suite(p256_sswu_nu, p256_order)
+    _test_suite(p256_svdw_nu, p256_order)
 
 if __name__ == "__main__":
     test_suite_p256()

--- a/poc/suite_p384.sage
+++ b/poc/suite_p384.sage
@@ -3,7 +3,6 @@
 
 import hashlib
 import sys
-
 try:
     from sagelib.common import sgn0_le
     from sagelib.h2c_suite import BasicH2CSuiteDef, BasicH2CSuite

--- a/poc/suite_p384.sage
+++ b/poc/suite_p384.sage
@@ -3,6 +3,7 @@
 
 import hashlib
 import sys
+
 try:
     from sagelib.common import sgn0_le
     from sagelib.h2c_suite import BasicH2CSuiteDef, BasicH2CSuite
@@ -18,18 +19,22 @@ F = GF(p)
 A = F(-3)
 B = F(0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef)
 
-p384_sswu_def = BasicH2CSuiteDef(F, A, B, sgn0_le, hashlib.sha512, 72, GenericSSWU, 1, True, DST)
+p384_sswu_def = BasicH2CSuiteDef("P384", F, A, B, sgn0_le, hashlib.sha512, 72, GenericSSWU, 1, True, DST)
 p384_svdw_def = p384_sswu_def._replace(MapT=GenericSvdW)
-p384_sswu = BasicH2CSuite(p384_sswu_def)
-p384_svdw = BasicH2CSuite(p384_svdw_def)
-assert p384_sswu.m2c.Z == -12
-assert p384_svdw.m2c.Z == -1
+p384_sswu_ro = BasicH2CSuite("P384-SHA512-SSWU-RO-",p384_sswu_def)
+p384_svdw_ro = BasicH2CSuite("P384-SHA512-SVDW-RO-",p384_svdw_def)
+p384_sswu_nu = BasicH2CSuite("P384-SHA512-SSWU-NU-",p384_sswu_def._replace(is_ro=False))
+p384_svdw_nu = BasicH2CSuite("P384-SHA512-SVDW-NU-",p384_svdw_def._replace(is_ro=False))
+assert p384_sswu_ro.m2c.Z == p384_sswu_nu.m2c.Z == -12
+assert p384_svdw_ro.m2c.Z == p384_svdw_nu.m2c.Z == -1
 
 p384_order = 0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973
 
 def test_suite_p384():
-    _test_suite(p384_sswu, p384_order)
-    _test_suite(p384_svdw, p384_order)
+    _test_suite(p384_sswu_ro, p384_order)
+    _test_suite(p384_svdw_ro, p384_order)
+    _test_suite(p384_sswu_nu, p384_order)
+    _test_suite(p384_svdw_nu, p384_order)
 
 if __name__ == "__main__":
     test_suite_p384()

--- a/poc/suite_p521.sage
+++ b/poc/suite_p521.sage
@@ -3,7 +3,6 @@
 
 import hashlib
 import sys
-
 try:
     from sagelib.common import sgn0_le
     from sagelib.h2c_suite import BasicH2CSuiteDef, BasicH2CSuite

--- a/poc/suite_p521.sage
+++ b/poc/suite_p521.sage
@@ -3,6 +3,7 @@
 
 import hashlib
 import sys
+
 try:
     from sagelib.common import sgn0_le
     from sagelib.h2c_suite import BasicH2CSuiteDef, BasicH2CSuite
@@ -18,18 +19,22 @@ F = GF(p)
 A = F(-3)
 B = F(0x51953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00)
 
-p521_sswu_def = BasicH2CSuiteDef(F, A, B, sgn0_le, hashlib.sha512, 96, GenericSSWU, 1, True, DST)
+p521_sswu_def = BasicH2CSuiteDef("P384", F, A, B, sgn0_le, hashlib.sha512, 96, GenericSSWU, 1, True, DST)
 p521_svdw_def = p521_sswu_def._replace(MapT=GenericSvdW)
-p521_sswu = BasicH2CSuite(p521_sswu_def)
-p521_svdw = BasicH2CSuite(p521_svdw_def)
-assert p521_sswu.m2c.Z == -4
-assert p521_svdw.m2c.Z == 1
+p521_sswu_ro = BasicH2CSuite("P521-SHA512-SSWU-RO-",p521_sswu_def)
+p521_svdw_ro = BasicH2CSuite("P521-SHA512-SVDW-RO-",p521_svdw_def)
+p521_sswu_nu = BasicH2CSuite("P521-SHA512-SSWU-NU-",p521_sswu_def._replace(is_ro=False))
+p521_svdw_nu = BasicH2CSuite("P521-SHA512-SVDW-NU-",p521_svdw_def._replace(is_ro=False))
+assert p521_sswu_ro.m2c.Z == p521_sswu_nu.m2c.Z == -4
+assert p521_svdw_ro.m2c.Z == p521_svdw_nu.m2c.Z == 1
 
 p521_order = 0x1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409
 
 def test_suite_p521():
-    _test_suite(p521_sswu, p521_order)
-    _test_suite(p521_svdw, p521_order)
+    _test_suite(p521_sswu_ro, p521_order)
+    _test_suite(p521_svdw_ro, p521_order)
+    _test_suite(p521_sswu_nu, p521_order)
+    _test_suite(p521_svdw_nu, p521_order)
 
 if __name__ == "__main__":
     test_suite_p521()

--- a/poc/suite_secp256k1.sage
+++ b/poc/suite_secp256k1.sage
@@ -23,18 +23,22 @@ Ap = F(0x3f8731abdd661adca08a5558f0f5d272e953d363cb6f0e5d405447c01a444533)
 Bp = F(1771)
 iso_map = iso_secp256k1()
 
-secp256k1_svdw_def = BasicH2CSuiteDef(F, A, B, sgn0_le, hashlib.sha256, 48, GenericSvdW, 1, True, DST)
+secp256k1_svdw_def = BasicH2CSuiteDef("secp256k1", F, A, B, sgn0_le, hashlib.sha256, 48, GenericSvdW, 1, True, DST)
 secp256k1_sswu_def = IsoH2CSuiteDef(secp256k1_svdw_def._replace(MapT=GenericSSWU), Ap, Bp, iso_map)
-secp256k1_svdw = BasicH2CSuite(secp256k1_svdw_def)
-secp256k1_sswu = IsoH2CSuite(secp256k1_sswu_def)
-assert secp256k1_sswu.m2c.Z == -11
-assert secp256k1_svdw.m2c.Z == 1
+secp256k1_sswu_ro = IsoH2CSuite("secp256k1-SHA256-SSWU-RO-",secp256k1_sswu_def)
+secp256k1_svdw_ro = BasicH2CSuite("secp256k1-SHA256-SVDW-RO-",secp256k1_svdw_def)
+secp256k1_sswu_nu = IsoH2CSuite("secp256k1-SHA256-SSWU-NU-",secp256k1_sswu_def._replace(base=secp256k1_sswu_def.base._replace(is_ro=False)))
+secp256k1_svdw_nu = BasicH2CSuite("secp256k1-SHA256-SVDW-NU-",secp256k1_svdw_def._replace(is_ro=False))
+assert secp256k1_sswu_ro.m2c.Z == secp256k1_sswu_nu.m2c.Z == -11
+assert secp256k1_svdw_ro.m2c.Z == secp256k1_svdw_nu.m2c.Z == 1
 
 secp256k1_order = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
 
 def test_suite_secp256k1():
-    _test_suite(secp256k1_sswu, secp256k1_order)
-    _test_suite(secp256k1_svdw, secp256k1_order)
+    _test_suite(secp256k1_sswu_ro, secp256k1_order)
+    _test_suite(secp256k1_svdw_ro, secp256k1_order)
+    _test_suite(secp256k1_sswu_nu, secp256k1_order)
+    _test_suite(secp256k1_svdw_nu, secp256k1_order)
 
 if __name__ == "__main__":
     test_suite_secp256k1()

--- a/poc/svdw_generic.sage
+++ b/poc/svdw_generic.sage
@@ -11,6 +11,7 @@ except ImportError:
 
 class GenericSvdW(GenericMap):
     def __init__(self, F, A, B):
+        self.name = "SVDW"
         self.F = F
         A = F(A)
         B = F(B)

--- a/poc/test.sage
+++ b/poc/test.sage
@@ -5,7 +5,7 @@ import sys
 
 from hash_to_base import test_hkdf
 
-print "Importing modules..."
+print("Importing modules...")
 
 try:
     from sagelib.common import test_ts

--- a/poc/test.sage
+++ b/poc/test.sage
@@ -5,6 +5,8 @@ import sys
 
 from hash_to_base import test_hkdf
 
+print "Importing modules..."
+
 try:
     from sagelib.common import test_ts
     from sagelib.ell2_generic import GenericEll2

--- a/poc/test_vectors.sage
+++ b/poc/test_vectors.sage
@@ -1,0 +1,95 @@
+#!/usr/bin/sage
+# vim: syntax=python
+
+import json
+
+print "Importing modules..."
+
+from sagelib.suite_p256 import \
+    p256_sswu_ro, \
+    p256_sswu_nu, \
+    p256_svdw_ro, \
+    p256_svdw_nu
+from sagelib.suite_p384 import \
+    p384_sswu_ro, \
+    p384_sswu_nu, \
+    p384_svdw_ro, \
+    p384_svdw_nu
+from sagelib.suite_p521 import \
+    p521_sswu_ro, \
+    p521_sswu_nu, \
+    p521_svdw_ro, \
+    p521_svdw_nu
+from sagelib.suite_secp256k1 import \
+    secp256k1_sswu_ro, \
+    secp256k1_sswu_nu, \
+    secp256k1_svdw_ro, \
+    secp256k1_svdw_nu
+from sagelib.suite_25519 import \
+    edw25519_hash_ro,   \
+    monty25519_hash_ro, \
+    edw25519_hash_nu,   \
+    monty25519_hash_nu
+from sagelib.suite_448 import \
+    edw448_hash_ro,   \
+    monty448_hash_ro, \
+    edw448_hash_nu,   \
+    monty448_hash_nu
+from sagelib.suite_bls12381g1 import \
+    bls12381g1_svdw_ro, \
+    bls12381g1_sswu_ro, \
+    bls12381g1_svdw_nu, \
+    bls12381g1_sswu_nu
+from sagelib.suite_bls12381g2 import \
+    bls12381g2_svdw_ro, \
+    bls12381g2_sswu_ro, \
+    bls12381g2_svdw_nu, \
+    bls12381g2_sswu_nu
+
+def print_gf(num):
+    return ','.join(["{0:#x}".format(ZZ(ni)) for ni in list(num.polynomial())])
+
+
+def print_point(point):
+    if point.is_zero():
+        return {"inf": True}
+    else:
+        x,y,z = point
+        return {"x": print_gf(x), "y": print_gf(y)}
+
+def create_vectors(h2c):
+    vectors = []
+    for msg in INPUTS:
+        point = h2c(msg)
+        vectors += [{"msg": msg, "P": print_point(point)}]
+    return {"vectors": vectors}
+
+
+def json_vectors(h2c, vectors_path="vectors"):
+    print("Generating: " + h2c.suite_name)
+    file = open(vectors_path + "/" + h2c.suite_name + ".json", 'w')
+    out = h2c.__dict__()
+    out.update(create_vectors(h2c))
+    json.dump(out, file, sort_keys=True, indent=2)
+    file.close()
+
+
+INPUTS = ["", "abc", "abcdef0123456789", "a512_"+"a"*512]
+
+ALL_SUITES = [
+    p256_sswu_ro, p384_sswu_ro, p521_sswu_ro, secp256k1_sswu_ro,
+    p256_sswu_nu, p384_sswu_nu, p521_sswu_nu, secp256k1_sswu_nu,
+    p256_svdw_ro, p384_svdw_ro, p521_svdw_ro, secp256k1_svdw_ro,
+    p256_svdw_nu, p384_svdw_nu, p521_svdw_nu, secp256k1_svdw_nu,
+    edw25519_hash_ro, edw448_hash_ro,
+    edw25519_hash_nu, edw448_hash_nu,
+    monty25519_hash_ro, monty448_hash_ro,
+    monty25519_hash_nu, monty448_hash_nu,
+    bls12381g1_svdw_ro, bls12381g2_svdw_ro,
+    bls12381g1_sswu_ro, bls12381g2_sswu_ro,
+    bls12381g1_svdw_nu, bls12381g2_svdw_nu,
+    bls12381g1_sswu_nu, bls12381g2_sswu_nu,
+    ]
+
+for suite in ALL_SUITES:
+    json_vectors(suite)

--- a/poc/test_vectors.sage
+++ b/poc/test_vectors.sage
@@ -2,76 +2,81 @@
 # vim: syntax=python
 
 import json
+import sys
 
-print "Importing modules..."
+print("Importing modules...")
 
-from sagelib.suite_p256 import \
-    p256_sswu_ro, \
-    p256_sswu_nu, \
-    p256_svdw_ro, \
-    p256_svdw_nu
-from sagelib.suite_p384 import \
-    p384_sswu_ro, \
-    p384_sswu_nu, \
-    p384_svdw_ro, \
-    p384_svdw_nu
-from sagelib.suite_p521 import \
-    p521_sswu_ro, \
-    p521_sswu_nu, \
-    p521_svdw_ro, \
-    p521_svdw_nu
-from sagelib.suite_secp256k1 import \
-    secp256k1_sswu_ro, \
-    secp256k1_sswu_nu, \
-    secp256k1_svdw_ro, \
-    secp256k1_svdw_nu
-from sagelib.suite_25519 import \
-    edw25519_hash_ro,   \
-    monty25519_hash_ro, \
-    edw25519_hash_nu,   \
-    monty25519_hash_nu
-from sagelib.suite_448 import \
-    edw448_hash_ro,   \
-    monty448_hash_ro, \
-    edw448_hash_nu,   \
-    monty448_hash_nu
-from sagelib.suite_bls12381g1 import \
-    bls12381g1_svdw_ro, \
-    bls12381g1_sswu_ro, \
-    bls12381g1_svdw_nu, \
-    bls12381g1_sswu_nu
-from sagelib.suite_bls12381g2 import \
-    bls12381g2_svdw_ro, \
-    bls12381g2_sswu_ro, \
-    bls12381g2_svdw_nu, \
-    bls12381g2_sswu_nu
+try:
+    from printer import Printer
+    from sagelib.suite_p256 import \
+        p256_sswu_ro, \
+        p256_sswu_nu, \
+        p256_svdw_ro, \
+        p256_svdw_nu
+    from sagelib.suite_p384 import \
+        p384_sswu_ro, \
+        p384_sswu_nu, \
+        p384_svdw_ro, \
+        p384_svdw_nu
+    from sagelib.suite_p521 import \
+        p521_sswu_ro, \
+        p521_sswu_nu, \
+        p521_svdw_ro, \
+        p521_svdw_nu
+    from sagelib.suite_secp256k1 import \
+        secp256k1_sswu_ro, \
+        secp256k1_sswu_nu, \
+        secp256k1_svdw_ro, \
+        secp256k1_svdw_nu
+    from sagelib.suite_25519 import \
+        edw25519_hash_ro,   \
+        edw25519_hash_nu,   \
+        monty25519_hash_ro, \
+        monty25519_hash_nu
+    from sagelib.suite_448 import \
+        edw448_hash_ro,   \
+        edw448_hash_nu,   \
+        monty448_hash_ro, \
+        monty448_hash_nu
+    from sagelib.suite_bls12381g1 import \
+        bls12381g1_svdw_ro, \
+        bls12381g1_sswu_ro, \
+        bls12381g1_svdw_nu, \
+        bls12381g1_sswu_nu
+    from sagelib.suite_bls12381g2 import \
+        bls12381g2_svdw_ro, \
+        bls12381g2_sswu_ro, \
+        bls12381g2_svdw_nu, \
+        bls12381g2_sswu_nu
 
-def print_gf(num):
-    return ','.join(["{0:#x}".format(ZZ(ni)) for ni in list(num.polynomial())])
-
-
-def print_point(point):
-    if point.is_zero():
-        return {"inf": True}
-    else:
-        x,y,z = point
-        return {"x": print_gf(x), "y": print_gf(y)}
-
-def create_vectors(h2c):
-    vectors = []
-    for msg in INPUTS:
-        point = h2c(msg)
-        vectors += [{"msg": msg, "P": print_point(point)}]
-    return {"vectors": vectors}
+except ImportError:
+    sys.exit("Error loading preprocessed sage files. Try running `make clean pyfiles`")
 
 
-def json_vectors(h2c, vectors_path="vectors"):
-    print("Generating: " + h2c.suite_name)
-    file = open(vectors_path + "/" + h2c.suite_name + ".json", 'w')
-    out = h2c.__dict__()
-    out.update(create_vectors(h2c))
-    json.dump(out, file, sort_keys=True, indent=2)
-    file.close()
+def file_json(h2c, _vectors, path="vectors"):
+    with open(path + "/" + h2c.suite_name + ".json", 'wt') as file:
+        out = h2c.__dict__()
+        all_vec = [{
+            "msg": vec[0],
+            "P": Printer.math.point(vec[1]), } for vec in _vectors]
+        out.update({"vectors": all_vec})
+        json.dump(out, file, sort_keys=True, indent=2)
+
+
+def file_ascii(h2c, _vectors, path="ascii"):
+    with open(path + "/" + h2c.suite_name + ".txt", 'wt') as file:
+        file.write(Printer.tv.text("suite", h2c.suite_name)+"\n")
+        file.write(Printer.tv.text("dst", h2c.dst)+"\n")
+        for vec in _vectors:
+            file.write(Printer.tv.text("msg", vec[0])+"\n")
+            file.write(Printer.tv.point(vec[1])+"\n")
+
+
+def create_files(suite):
+    print("Generating: " + suite.suite_name)
+    vectors = [(msg, suite(msg)) for msg in INPUTS]
+    file_json(suite, vectors)
+    file_ascii(suite, vectors)
 
 
 INPUTS = ["", "abc", "abcdef0123456789", "a512_"+"a"*512]
@@ -89,7 +94,7 @@ ALL_SUITES = [
     bls12381g1_sswu_ro, bls12381g2_sswu_ro,
     bls12381g1_svdw_nu, bls12381g2_svdw_nu,
     bls12381g1_sswu_nu, bls12381g2_sswu_nu,
-    ]
+]
 
-for suite in ALL_SUITES:
-    json_vectors(suite)
+if __name__ == '__main__':
+    map(create_files, ALL_SUITES)

--- a/poc/test_vectors.sage
+++ b/poc/test_vectors.sage
@@ -29,10 +29,14 @@ try:
         secp256k1_svdw_ro, \
         secp256k1_svdw_nu
     from sagelib.suite_25519 import \
-        edw25519_hash_ro,   \
-        edw25519_hash_nu,   \
-        monty25519_hash_ro, \
-        monty25519_hash_nu
+        edw25519_sha256_ro,   \
+        edw25519_sha256_nu,   \
+        monty25519_sha256_ro, \
+        monty25519_sha256_nu, \
+        edw25519_sha512_ro,   \
+        edw25519_sha512_nu,   \
+        monty25519_sha512_ro, \
+        monty25519_sha512_nu
     from sagelib.suite_448 import \
         edw448_hash_ro,   \
         edw448_hash_nu,   \
@@ -86,10 +90,10 @@ ALL_SUITES = [
     p256_sswu_nu, p384_sswu_nu, p521_sswu_nu, secp256k1_sswu_nu,
     p256_svdw_ro, p384_svdw_ro, p521_svdw_ro, secp256k1_svdw_ro,
     p256_svdw_nu, p384_svdw_nu, p521_svdw_nu, secp256k1_svdw_nu,
-    edw25519_hash_ro, edw448_hash_ro,
-    edw25519_hash_nu, edw448_hash_nu,
-    monty25519_hash_ro, monty448_hash_ro,
-    monty25519_hash_nu, monty448_hash_nu,
+    edw25519_sha256_ro, edw25519_sha512_ro, edw448_hash_ro,
+    edw25519_sha256_nu, edw25519_sha512_nu, edw448_hash_nu,
+    monty25519_sha256_ro, monty25519_sha512_ro, monty448_hash_ro,
+    monty25519_sha256_nu, monty25519_sha512_nu, monty448_hash_nu,
     bls12381g1_svdw_ro, bls12381g2_svdw_ro,
     bls12381g1_sswu_ro, bls12381g2_sswu_ro,
     bls12381g1_svdw_nu, bls12381g2_svdw_nu,

--- a/poc/test_vectors.sage
+++ b/poc/test_vectors.sage
@@ -97,4 +97,4 @@ ALL_SUITES = [
 ]
 
 if __name__ == '__main__':
-    map(create_files, ALL_SUITES)
+    list(map(create_files, ALL_SUITES))

--- a/poc/vectors/BLS12381G1-SHA256-SSWU-NU-.json
+++ b/poc/vectors/BLS12381G1-SHA256-SSWU-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "BLS12381G1-SHA256-SSWU-NU-",
+  "curve": "BLS12381G1",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_be"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x121b8d2473aedf640a883c96dc836419f713c647c6e8b69f48faf537a222a385b8606e7ce0afd2bdb51f02ee2c5947e4",
+        "y": "0x1109190675bf5f0c9491ba80c9cb41a646136b5797cb66740d5a346fe0277af2666e888c011e4919522325c391a698a7"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x0eb678eb72d1224fd0c7a848aa39f248da56a65c772c8847ebedbad1c064b1a7ba7b1d3e30857e1ba7250a8176d34252",
+        "y": "0x04afae28aff5381fa18c26f48480229c9f4e4fb501ef34c0495f854bfd12d13ca0561f5f25ae9caad2689043257f22ad"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x17170051f9302c4a49fc20cd33b079382c8bfad2af50732e131aa4c105930446b0f0e9fd8e62ef4cca2c9cd1cc8d1fef",
+        "y": "0x18b795a49884d4669f7b9888047ab74d0a4209f0969d79cd9c0fa255dc77ca14ca7a686965444c3bee81cfea0ed846e3"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x0601eb855db0e099ed00befc0f32ec9e874e6cb238bf69b76beb2e6c024763a95c973aa855b3f398bca1e44e1e8693c5",
+        "y": "0x11c2723f78d514df64a53113d16de8b2b6d643f672046c59f321e1422222ff06dee768c99f579b3067a1ad441dc5418d"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/BLS12381G1-SHA256-SSWU-RO-.json
+++ b/poc/vectors/BLS12381G1-SHA256-SSWU-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "BLS12381G1-SHA256-SSWU-RO-",
+  "curve": "BLS12381G1",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_be"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x0ca5ca55eae80a39cd9c3587bcf7c7f8af9df7e382e154645537d71131a960b09b97852e889f58b58b3c3482aaf32c29",
+        "y": "0x1519edd2d51bdc3513ee8e676e2466878b293b338917576155978192c62191083ea81790ab91d9f17799d1e7ef75c836"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x1375281934d938ed0fe24f12b2bc799b2a2a0f2bc2b2f67f859964d92225d4a122362c310586d80b3e28f1023a9af139",
+        "y": "0x1840e3fdac47a0d6d00bcc7816560b385722919f9297c1852c262866eb0b5707dc4ea205c17b9d456f88da6ced7f2dad"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x104004ecf9b7359522373c663b893d798619b1291622907c908123d44cc182cd0fffc0ad8710f8fbb4ae7328424b7ce6",
+        "y": "0x09c8de2e1b260b36ac3e51ab2de585391d176a69cbe6cdb3e3c60f4a48dad143affdc2aa8dc4d8581d4d92cbe00ac001"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x0ecea084aafffae1cc42bb59a1ddbcdef8939f3c580389c6d9b1e1f0d0f5f73dde5cd2ec7958c38742328497442619c8",
+        "y": "0x1363f9b441a0dc2500357ea5c249a675ea0bfeb03f597ba381a33f96161fd12705b97153917df5b8279b0de44920e382"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/BLS12381G1-SHA256-SVDW-NU-.json
+++ b/poc/vectors/BLS12381G1-SHA256-SVDW-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "BLS12381G1-SHA256-SVDW-NU-",
+  "curve": "BLS12381G1",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_be"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x08d8b168556f3f2f86010cd32c3a49dec17f4c29b4fa4ac4f71d3c72fc1d69ec56cf748a3149161e5ac46cd42d4925e0",
+        "y": "0x18e994479c3a4c21eb369ae4a9d5698ab63711f393c2a0174804504c4d6f1f772cb059feff43367645ade9ec1effcdce"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x032786275aed9d394e5dbec59c19b80e57a377d842e6cf4ec8d8b7153f4e765cf85e29526a95696f806f6abf2c9b8431",
+        "y": "0x16e22d16278645511b1b0a2f8085b09345b5fcc89d6c3311196d36040c4ac8437a19844ef84eae9e123250152eeea1d7"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x0943b1406f7d8db03093b025ccfe2f4deeadb03efca631966d735bf88485ed5ebf883910bc235e795477b07b6c873cc8",
+        "y": "0x0adb9e576b25235be1a416a33a6d474efc681a0ab06b85e67affe2d625bf18feeb9dfbc2d5b9d6cfe3fddd6e8a0d979c"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x0d929e9ec79ff71e8048263740f3f0a4da80211652909f969c9746305e8d42aef1ef447351945229ce85f22f6c1889a1",
+        "y": "0x004cf71c71dd867d853e1fa0cad78e826daa75cd3133f5716fa5d3938b2f91b08842acfaa901780cd62edf610b9fc622"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/BLS12381G1-SHA256-SVDW-RO-.json
+++ b/poc/vectors/BLS12381G1-SHA256-SVDW-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "BLS12381G1-SHA256-SVDW-RO-",
+  "curve": "BLS12381G1",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_be"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x1632264ecfb78c1c1925040678db46c4662c2f91858aa40a417a2962c76cfa6ede89d85128b5bc595efe5dc51b198288",
+        "y": "0x15ffa01397282c4c7bb80dced876bff28fca7875b2ca2afd7ccb600234e5f79c51c8fe4a7fe318514ab96a395985cc39"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x031a4a258c4d692cf1164e6c1b23de61e60dfabe0e73155e4b4465da10a23498aaf137c4d23cd306a4ad56e3a043e726",
+        "y": "0x198775d43be5cf0ad6a2d99a014ea213e90125b49690e0396ebb84dd3a7ee6f8212228121499b7ff4fe156daef78e873"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x05eb8513c4ce4020d4b7926ed60361ab6ea673dbcab6ad300fc6b6cc70a8811b7def375458e11cd1fd2246b2cb481225",
+        "y": "0x04e43c5e9e99b806f6fc9c0138d6aa558e5d5c833565b4a648665202cc4eb1bf5a5f7dd77b6416bcca7dfce5facbe768"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x013843b1a17e83359cb5af9758ee138ab2ecab6c3feeee4df4776436bf5db8c5f37f5ea871aeae12565d908cb5e8d63b",
+        "y": "0x186cc8a6335526b125ec9319d7d38e62402064d5557d3c6d3dd36a314dfc08aa69975d29511248a39edf5acbd4818beb"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/BLS12381G2-SHA256-SSWU-NU-.json
+++ b/poc/vectors/BLS12381G2-SHA256-SSWU-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "BLS12381G2-SHA256-SSWU-NU-",
+  "curve": "BLS12381G2",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x2",
+    "p": "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_be"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x046d50484e390253270993a1f4ad3ce509e5f23284394443adb41629dedbc49dc5816c3a348ad844491d7b7e0ee8ee70,0x123481229179ba928292828873dd005d0f30673ec8f9429237986ab115049526d48300d7efa7aa492526c6f7d6cd4c15",
+        "y": "0x019fea23863e58a7e7a30079043a71e295bf1ea8539f4566bf5b049b54225a60764dfd5cb33cf0ed8b62ade34921f517,0x03a84a3590ca52f3029dab760848099a3a90bc988eb59beae2bb9bff6f82929dff66f0e3d68fa1903bfb191a2e085b11"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x054c7bbb544e9df3ebb45a863c22e84336af0511ddab82f4eec3efd96e90391b883011a6c81dd619f89d13ac4e947cb7,0x12bdd882c550923779b483f485549534109ce8a368663906d77376fd4b5d2be7165693752a848b1afccb33ad641079ba",
+        "y": "0x17d9d29b3f4f2b442452173feb0ea11f0d37968e091e80cf918fcbce55f4b24a3552293c0c33a8673a4ba973d72f8349,0x099b28ec45155b96c62548f7dd03953094596460126a1a845a69600176e5dd8543b883e8b22df93d3a7a023d20ec016f"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x07a60b12f6e1abb75e8091feb775f16273a23cf1648309060f59c363c9b5cb7de3018c54e810b4086300d8ae3472062e,0x114ce2abe0bc178415c26599aa633a79502d64843a6351947b56c23bc70fa5b47bd777aad73d7f7f68b6f43d6334032d",
+        "y": "0x0634fce28f8ac37f0e93a435c392232c3dc4064fa39aec9b9fdda31fa2525a5371ed607ec8f0dc7d1bf50b6007876e56,0x07533ecfa9874c0789d7b5d6f977e91e35200640d8e23babf4e65fdc4e7845bc266cdd4a29d4479b67d6fba8e250b159"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x087c8eaee52598d127fdb26d761a17c5cb21602386018a94ac53e332b6a6fc3ea5630ddccbe26320dbc357982404c0b5,0x03c17d90468bf983472e38bad785528e6f2ac0c5d44db2ad9e3fbc36bcfd10637c96194c2fe713b660030ccfe2d71284",
+        "y": "0x1903ae5a913a6acd5995fb5bc06582746238dad84f59f42678a86d0fefcd875f0fc4777671c3b1be08a67b2d09bf4d3f,0x02b2354c1d7bbb3eef7a91295ef3923d9c5ff7f21cd27f2042d30c844b5d6430303e6220f0117d58283bbc719e7e1fee"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/BLS12381G2-SHA256-SSWU-RO-.json
+++ b/poc/vectors/BLS12381G2-SHA256-SSWU-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "BLS12381G2-SHA256-SSWU-RO-",
+  "curve": "BLS12381G2",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x2",
+    "p": "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_be"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x036528905634e7526e9b430e891b6cb0ec7b6179bb27831b3e229b5fce4753955f1d76097cdcc2d6623adf6fded7cefb,0x0b2129974092c9b11d61e162b78879e7b4e4866b2783b9732257b5f5ad4641ff20eaee2db549318aafe0ddced6951c44",
+        "y": "0x17b8e33f17e4100fdb7976ef3e94dfece4e9c2917904140c62b598a319f5a88aa360440d6411fdde079c844036f4341c,0x05a4ae8fd3c367d8fe3428547faa67694777f6dc9318c96dd27cf905b0cab3cc042fe93b62a6044603fea98258b152c1"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x138523e71e5b41dfbb032ea47afe3e80641828ae8e5c39205cc48b8900bd9ed1d51bc7bc2010d58bf5119f056bb91133,0x05c0f0f93f81a0595f015b56baa5b3b9ccbdaf352d0f57e2943c8cf532605ac69e72f63f3db66ccbe0c703f6cb81bdb4",
+        "y": "0x059e9b4f9fd1103032d9065b3b36d1e5a54a5e291e80dfee77775b3c48a1f88229554128718cbddf99eaa85d72c8e8b3,0x19ce8bb5293ee2bb5cc6f5a909e6b4fde8515b4bd541afb92baeea97793615f768bd23a04ec2ff52f915f0d56284b3b5"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x18ee4d4505fd9d1ec85ad56ced1db17650fd19c2aa0dc9e73b0564e95b3be77713b1e3edc631a6c5804897b687709daa,0x0f4a954b93d31ed8d580b303443e5cf1595e42287249ac4ffb07246032fd6ec7d9e34bfaab65f8fcdccb77544c489221",
+        "y": "0x04717b6b4a247596392b749ee7c9fc6342227aa80183c79a66d8a85509c3efd0079f74f12811cee984aafefc56074b97,0x0d6267ddea737854e17fa4fd8591feeda58357b2e853b9898ad5db420c1b29e9a7c4ad936bb147a32db6f604ee93c2da"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x19c0c3d3d4a558d7a6708399d68205f1c1eab4a20ead4f3256710548a4c286952c576265f57a3d91ada1dea83e946caf,0x10f254a8b0aefac56edd1a9785aba7144bc72a6a1446d29b0c713d7f364f39e092a4bb22060d1ca399d512a72f1b5e32",
+        "y": "0x0f48be929002737cec3e5d72b37f91f7b31994e0575e30e73e4608ac1d300cd5bb7cc4ebf0e531911698b69a6e14b1f1,0x1923f4e6fbc6220fda5313cca06ff33dbd57584181e94bb95ede1c3f40806dc310c5e2bf00bacc143692fc751beee500"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/BLS12381G2-SHA256-SVDW-NU-.json
+++ b/poc/vectors/BLS12381G2-SHA256-SVDW-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "BLS12381G2-SHA256-SVDW-NU-",
+  "curve": "BLS12381G2",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x2",
+    "p": "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_be"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x094b4daaacea76cb0f30615f8f6d7aad7eba806854f0eaa31803d65a8039d6b1bee950103c94c23a342fc34b0990608e,0x0397333f2b2764c2deb814971fc7d5e8c34eb4139015fad4efa4577a5044d6d158e1d438f523bf489a519a45efae2175",
+        "y": "0x044328d9ccd80dfea8ead2727e65505290333ad2f304e3ca438c058f97fd8fc1458369d4cd921c1c6cdd4f76e7f44804,0x12392896a4d11fc55283750f8fa9b942f202a4d0c8b5814cf07e6b74821957332f2587829aef2a37cca2d6f31ad6da0b"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x05b3b4e050f836f29ec031fe571da56faa190f0c5aa01ceda13d25ea7ba330ae8f4a4b4ee9199c63b04b9c774c20bcff,0x0ea748f72df886ea9b7ba80079bcf3f1a1997a42b5938dca0c1eeaf1e9765c1fe5a8f7d7aa9f94b42058694f65265139",
+        "y": "0x09173fd01de58b5e2c92e49aadaaeda3c2694697f9dff61025bd00cd94e5f3f563dc35431e7772807261ebb6f5cee32b,0x103e7a146ea89d9aadfde27e374dfff54ba37a8bc241cb10947368f920ec9af5c067aa09f8d45553300ea9d43f5f3e31"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x13ab0bf6d84d70dfef324af4c1fef34033254d71e7332eca37a51124c7eb38e53bd17061a3552852a93c6007c322fb79,0x02e4ce337fa324b972b5a028873f45661785922ab7ae70220445496fe900acb91ddd1d5a4b3f78925752c503d333ca8e",
+        "y": "0x1656b01258bb905584174d244346d12f52f04a08a8addf560dccb1bb9158a032bced6b60ea149c2bf52849928137f1b4,0x02c1a17970d69bb6da6d13ce568a292a3554dcfc3988b11330923c820aec199f315594dccbd3442ee1c6e7c65f9b5fdd"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x11d09b5e3c6403dddc95e1b645b934f6b2e7909b3d33d24bf3c28f6a3b8494c96d89e0bddd20f6c61f07d152108393a0,0x13b08b0bcaa39af40c4426d7a28fb313c6988deb9de0bc85e48ebbb372cbc6eedd92350fcce064de44293c45c2097824",
+        "y": "0x00022f525abbee9d91f977bea2ed0f293bc3d141e92857b4e6519fceb3fd6a0b79c9f61306e039666e52a181d07ffac9,0x01bc509c0b3d45bc7fbc5b493894f483e37a3da4b54d7c1b008598d2a4cc891f9446206dd7c8a696aab038107fb63f3d"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/BLS12381G2-SHA256-SVDW-RO-.json
+++ b/poc/vectors/BLS12381G2-SHA256-SVDW-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "BLS12381G2-SHA256-SVDW-RO-",
+  "curve": "BLS12381G2",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x2",
+    "p": "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_be"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x174519eb4b8470578e1c0aed234b3324ccc604158319c897283a7aab657aaf853567aedc59049f7557c7be08cb1a2dd3,0x137cc8723b59b0b50a06dc2636bdd17edeb5c717f5d7971289bc8304e790eb3af3d4a99b789c4c7d5da2b2a565e2197c",
+        "y": "0x0b9f417fc9d1d30ccb485d9a4efb95502ea536850c6db4ac33016d1e49ce7f701f99cde0b0903c2f0f3d6f4977aa98b6,0x0cde237ee7b7b8f168f7ba96fa7bf7945d14456da7fc11a7c7ff09aa0ca813cc8fc5619de4968235b5b35c43447189ef"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x01264394bad2a147a79bbd6f3d77c2f5f8f29406f349322fb7ad8a84258f88197b0ddbd8f47790f71d007cd2b8f0f43b,0x160adc00662a84af2357632f13f80feeacbfa45017c29cacff5c0396ce3f40ab9c2c2df5390d71277c053c47feeb961f",
+        "y": "0x0d09312bd655138eeaba9ab475da8b336e3a616111203f573bcdad1c1a40038a09934c9001c3849326b14b33b721fe2a,0x169259130b6aa1a204c01ab2d83fca998cfdd7d14e9a81047b3e2ba11290e193adb1e925baa471ae13e846e0c6815567"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x01b81b5356acec37a0365ca0978214f706c64de8ec2b0257d02fad9c48c70183d8686e93e1b834cec31a41909d55c513,0x168402845b62a48dd15b51b3bd09b30e57e252b6e91f6af68e467f94f8e4d248c802c2ee51006ab7b3ef8ca9adb1d2dc",
+        "y": "0x18b146cbe5976aeef96fdf3d1f6d23df7573dd339e2c82c42c3af8698f3f3f5ec632b9ec3f1b16ae52d86606cd8e5ed1,0x07f95df0b67f458d8bf4957ff7f6b32a896279e9583e6f038436906b952ceba82422baa674b949159b146f597574cc88"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x02dec63dc9b0eec9869dee2789098aae84878f30885fc304ad31cde634ad32cd416e60f348752bdb9a29712e9951177b,0x05f0a4e1f3e545f7475b1d7d29b199b90c3c16116ac150a2c52bf46e1bbf78ecf900a7667b802d41df42d084c9ee908e",
+        "y": "0x07d641c22572f73c6f21f7dee331f327838c12b7cd3c63306ef188b97cb158a703d2ac83bf1caac9505b62570355781b,0x0d22167d2265b1dc410ca9937f7ddc4302a90d62106a63b860a9f6698982bee90b4382cad94a6f8803459ec99b817571"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P256-SHA256-SSWU-NU-.json
+++ b/poc/vectors/P256-SHA256-SSWU-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P256-SHA256-SSWU-NU-",
+  "curve": "P256",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x63a22809040899cbe4deeace9ec6ed8dad468994a22fac0403459f7e30d46977",
+        "y": "0x2bd9ab4bf865db041520cc2a124cde894fd7339f8e6de808122244423b94b396"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x04fef1ff8ac09b09ad9ebcc3801ef6ad8af4ddbe919c9abc0034d05e4b6cc9ce",
+        "y": "0x5531154d96da404f0dbc1b2717f882172234b0ef96c8724c47b80177b9cacdc6"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0xb7d140fc24109c144a32e27082bf9f06bdcf9a133c09f71b7fb125efd61ba4c8",
+        "y": "0xe3b6c3188325a8cdebab84797048fabe14c94e90279fcd4fd3b445d1bb9498ce"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x5fc65b513d1c4a78494dce090ea8d89e6ebfb1f2fe5ed0ea088a8f658bfbcc45",
+        "y": "0x7cd9cdefc46886b774e2b235dbed6120aa8a7f4d3b0d5543dce899a82c19c9cc"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P256-SHA256-SSWU-RO-.json
+++ b/poc/vectors/P256-SHA256-SSWU-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P256-SHA256-SSWU-RO-",
+  "curve": "P256",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x8beb73a82ebeb6b400456f4da126aacbfa9b8049b71b250d2b7e4885b6b466bd",
+        "y": "0x15826dc578f4fbc1ac5fc3f9e15da3ece18be914f332bce8ce5bf1371805d149"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x09e2d803a55cea537e5ef376860761cbb707a986d201e37ca93a1da5a8e254bc",
+        "y": "0xbf41e0430d2767129b6ab7a3da5bb090ce508c7f948f941f2f53fb3b37f6c7d2"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x4559eda8bf75f6ee31c1b164ac881f4254bc343e2fb064bfb391588330da7ad6",
+        "y": "0x1fd912349e7fed945c31405d50b9445e9db40944a3ebe9a7893e31c1bb345e57"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0xbb9e66681af1ca2b762bb27b07b79fa85568a5b7ed87c401a9e2f5e514d32649",
+        "y": "0xe4f183cbdaf6e2d938bf97fe3d38df06d8d53f0ec6bf455ea980bfcbd9b76eee"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P256-SHA256-SVDW-NU-.json
+++ b/poc/vectors/P256-SHA256-SVDW-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P256-SHA256-SVDW-NU-",
+  "curve": "P256",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0xc964659779fc0927175d201a1b985ad0c26780254938b5d3e12dbdeba4e7ed62",
+        "y": "0x6878391e85ee4a721bed3ffc14302037ff78330f45b73e12d8acf2a486ce8c70"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x838405946ae489d6a2041a7bf681f6194c59dc076224283619c757ab1fe08442",
+        "y": "0x0db831e49db534d85d7fc626c06b87950508d4d2024372d77fa1e6af3bad6b7c"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0xa42917f761f9f0999e5e6ca135104db4f066665a8363341fb7cde13c6f53c54d",
+        "y": "0x68d777b850478ccdfbf446983075a073c320b0d6c7407a7063b17a119647feea"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x9760b6a22e0cc8c698e4d85aa8678d1f5943957266526eaa72e67e802f7a78e2",
+        "y": "0x9206b181065cdff2f085891ac0603ee94d5823da3d4faf7db9a793c782fa8c42"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P256-SHA256-SVDW-RO-.json
+++ b/poc/vectors/P256-SHA256-SVDW-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P256-SHA256-SVDW-RO-",
+  "curve": "P256",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x48d5fda7204362d41de02c7b535c06e9efa350ab4434544e41fbb4d93cd80afb",
+        "y": "0x5e19ac13c34662d1c63ecae515917b27b2f39435649c1bb7cee26fd53935e057"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x397f86a497ab5f51df73cee85166248381bccf1185d806742e34f6660c1adfc9",
+        "y": "0xeff9e74d6a54da066a540367597841aa8f50201a55e0c571786839aa4c806ba9"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x779b08f0233bd194b3d89706dcf486a45e7971ef65392cfe7b5403ca61726bfd",
+        "y": "0x28383745e82deee7a439d0110994d07f5371ac94156486508099c2d773c8bb1c"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x09494531f07eca5039a32e00dc3fa6b6b3f22c8ab9aa0aed1290ee613db6a664",
+        "y": "0x258a931ce7e046e61fb1480b8ae710178aac6955081aafc8c092bd56ade85ca7"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P384-SHA512-SSWU-NU-.json
+++ b/poc/vectors/P384-SHA512-SSWU-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P384-SHA512-SSWU-NU-",
+  "curve": "P384",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x29a08ba348edd27e3771db01ccfc51f199562d3a89188877c8a125c84c4b15d0aedde708f4644a463949ae2d8e6a586e",
+        "y": "0xd2231c5cfc28ffe1b0f136b4c6077a514d76cd4f1376e14dad1057d4d7d7eeab3125819f7b53572c481c80ea0691fca1"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x42ba276e074b27eeb70f7bf5f38273827182423f8590959a6eac26454f46e38926ab576dafdc5d31fdf8b3fffe821aa4",
+        "y": "0xc8bf731dd9ccb826cfaae42ae5d51363587d823991857a3cdcffb43b2f0d6720dc69ccc0c3212020204f3b8de3665052"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x81b0687611f57883f873d5dbf3d86675237d0cd68deb7f31cda4c7a70995bc29a989e207525dabc98795b0179e6f6ac2",
+        "y": "0x4760618111508ecfb9b6263d83ca2beee9deee28bf8459feb7454406be209a64a97434d66a65e2fb971c7bb5f6966e8f"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x490e2566f624a38e50f3f4b0988ed1ee6effb8117ccadf309e7dc444dcce0b70b2393f4bd081f80096e5aa0aa4431b3f",
+        "y": "0xe6c8bb7a058c7b1eec59e6bb69be22eb8c04ac74edb3abf2f55233f3a5aa5d3f7c304064e159c0895658d410bba4dbf6"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P384-SHA512-SSWU-RO-.json
+++ b/poc/vectors/P384-SHA512-SSWU-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P384-SHA512-SSWU-RO-",
+  "curve": "P384",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x6aede0bbf8f498a3eaefa55ff5b619d3006a3911ae3d398c8821e31a248fd85239a83f6c536b77f73e686ed97ecd1111",
+        "y": "0xc27e713458ebfd377bdd81a9a73d800d4f6769b0e8ddf9369ef84a91536aa1f29a60dc7c5a9765a44b56951d91797f13"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x49015966ac2870aa1854378f4ec030458520d38519e61d682586291f9e005de4587acf000a71b44bbe98eb0dd4790ddb",
+        "y": "0x7ed595efc7282bc8c4c1641067a1585b5b20eb9754832025dc76e78856de6ad7d00fa8adca343fcdf37fe5fe6298e4c2"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0xd9b4cc421f6998172fad86aa499f530ad7967df6609db6640fcc1b816b4f9acd685ad2c0d3dc1b75160742ecc1eafd08",
+        "y": "0xb5f0e185ad76df45b9cea1e7bd78458b9cb1a23f5cb918a7652d0d716d8bbad95c1a473de3a0180a0c3d496840d2d0a2"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x481a6d76117ab5eed13d28aa16166d09da3a3e5adc341829247385520fbd42a65132eba21f70887dfb3bbc0a482a1088",
+        "y": "0x969416fd238f3e0c6617f6c89efac5ace2238445ca78349f3bc802d64eb084833dddbee66c703a5de3d44daaa632a8a4"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P384-SHA512-SVDW-NU-.json
+++ b/poc/vectors/P384-SHA512-SVDW-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P384-SHA512-SVDW-NU-",
+  "curve": "P384",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x9175c880913060823975df6754bb20afad3a5807ef94695f48f31fcf6cb06316625bf0562de63891e3e7186b671c640f",
+        "y": "0x21badacee69ad3d51bb496b27669975fb7f124c2160a17a045cfd6d38166e9e63843846e08d03e5dcd7297e5ec47c07d"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x8d5c59d57c711d10b99a283f4afaa6ca068a54fe912f44ed3fe672599c6a11e3ca4bd12867510f4a7d03ae09f5cb487b",
+        "y": "0xabc84a0b6117e004c42fe0d11fb94d333026787dd00120ad99846d2022a6f5d7efdd2063ef220e9b88cb76b2b034e272"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x27194d9446d0ec34510fc48725c3072b7594d23da63666349751070d82a2126369e7d7c879d27bcc04d2d47c17bc0b20",
+        "y": "0x578103a8cbc18914438e85feab62a7c5c3b82def3d11381aa28d2f13ffe3fc61c02b4d4b760cb1e11c1510f6435554fb"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x2a344dade36a94e64f9d97fa530280c703b00b8de04c0edddd695d1bce7a65c453c5bdafdcc04474e9a3f2c7d11c4adb",
+        "y": "0x76265911e475620c209578e95c68575a6580fb9843836980d4fb8844799ae6711d62d812ec0fdbacb7e87a27c6a7c48a"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P384-SHA512-SVDW-RO-.json
+++ b/poc/vectors/P384-SHA512-SVDW-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P384-SHA512-SVDW-RO-",
+  "curve": "P384",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0xd3f245bf18b99f0eefe7a824bea53630412dd7bf53743375b94934b6dd44a6f047b28dc61467d593a7757deb673bb67f",
+        "y": "0x234c238cedd7ad3a424191189d395ab594261bcffb28ed3d67e40241db1bb98e17e122275b23f82e23595cacaa0d31b0"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x6436a0faa2dd76a066858d8077ec67a83169947dcfd033176e2817ffdbee0d215781c5e345101f7411f9df3014c5fc78",
+        "y": "0x6e6ed8caf7a62d81fd47da03c4ae10f8410822d4775fa1035884f4019cb2722062e189667595060cab900f716e6d75a1"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x79c8978a64fe71611e38bcdd47dc617742a5f36c556fb6d2de2ed933d4f58ca6eb04bbf0f988775a6443bdee5889c817",
+        "y": "0x6a48590ef74700716eed828a0edc16794b021ca1e840f9bb29ad28268b3616271a6a79471d64314c54736b20b0a02ba0"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x5f89929755c9c43209affbd58f5df55461bf52f0098abb9a9f4e1ebcf721eef2f122d13a4c0a99116569d497cbf16153",
+        "y": "0x8295b8b87870866f1534f08a52367c29692624e8b11b665e884e406047277825555f4181b351365451aec50b0f1ef951"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P521-SHA512-SSWU-NU-.json
+++ b/poc/vectors/P521-SHA512-SSWU-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P521-SHA512-SSWU-NU-",
+  "curve": "P384",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x0047625fcf688e752e033badd49376598b9b724aaa876fb143a32ecb0558574a993f68a617681b5eb69e05214e29087724fa31e4bdfbd16ef49f432d7a1d420d3efb",
+        "y": "0x01464b92c6d3bed416a9765cd1182adc7b4e09104d845a86a82c558c7325db9161121de0c346f7979bb9becca422d2f5900fef27a3e38fe78a4ab492f8d26cba7da5"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x0110f211a7747a5a6fff0ee78d8398fd1b385f3b61cc1f8b155d374c80bd61d0ba958afe5bfb7ff9608547654fc5cf120822009cfddfb23e328c7437127a7dee2f38",
+        "y": "0x016c9b62dd9ce4ebc2dd90721d3edb539571579a4e586df6fb0b88847c41d2c225654468c5e90d2a48fa2cf9918b4227c92dc02ff146ef89cd18850f977fa167d1ce"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x0124e6f185917e5b2910c4523372d4f4e91ad78e27feefdbaf843b2a978e1cb99050dff9dca092eddafde96b771109f28a4d4819c1c3abdb005e04fba0ecb4d8ef26",
+        "y": "0x01954db4d65ce20e9980784b6bfbddbb7f294b0e8825ea482c3ee80601dcc8cd936b5a32be6c8b3f2c8d9fe47422589f44de22f8b17fea8ca0b2efc3c208468625a1"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x01f508aa7c98165e3275c48592490a92501c4a15233da4ead216a0b42b4f8ef069b6563d81a359e101db016f6dab56f70cb10022abe875eb552166fe8db327d1cc53",
+        "y": "0x0104ffd08d21a3b64b1d60bb646cabd2fad4628dbed5925f4ac818a00d306207fd13b3e82c097015b8318ed49ba26daf09136209af28ba280c325d09d33457986d6e"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P521-SHA512-SSWU-RO-.json
+++ b/poc/vectors/P521-SHA512-SSWU-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P521-SHA512-SSWU-RO-",
+  "curve": "P384",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x000db5ae86c4a7ca7fb8c4588db0dec222d2220183a0d98ba9e9ab1f43955a8b27e3bc864facc4d199d8466ea8e6c0d1c41a6468a2a227bc71ef9685f2ccbc539cdd",
+        "y": "0x01d4487d9408b58ff71fea536f6761a8e1d3a851932fbd2706ca473e82bd494b92845cd4e3353fe5ff8a6b6200a3288bf5f76e962ef6297ba17a8d29540fa4ad78d3"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x0087eade308789ef88d2463366d6eef8f3389b8cc01ef4ed30e32d09ace10f870e86038de04e1995967c821861fe85783ceca67063f7b06fc404e0662a18b3e48ac0",
+        "y": "0x01a83d54da03146c442182ccc976e9e1da2424f23d158c5c12c6bda3b250b66d6305b152a39d1fdca940f17d046cd2117aac731b9996d56e0ebfeb9266e425273666"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x0124a71e5274f09d098fe4d0b89a0ed673275293a35d65ec38a0bf18b3c5c249a91d0538e3804aecb68f2e05182935e28b33da9ac58ba837a2c7623c321477ee8fa1",
+        "y": "0x011f560aa421178ffddb2df1b015f296640ab22a8c782aed4850673ad25f86d230f0fd9404bad6936b3ad3a86ef12888eaf18a2870b405e8fd1d2d728deef43769ec"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x0063b4f545c951c9be623ed6cb1adb51d181ec8a603d8f2430f5853ecfe98ee4bcb624ef6c51167f95ce5d95e70731f3f506e778f5f0cce7524bb562fedb496eddeb",
+        "y": "0x014831a46b2f77eb8737844e8079d3707d2b6a6a7ecff7f1a3986bcfa62b1edc1de8098641f945f3ab8a5fbdcf53c3c71021962d35b6bfeaae1012dd577c1b45f15a"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P521-SHA512-SVDW-NU-.json
+++ b/poc/vectors/P521-SHA512-SVDW-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P521-SHA512-SVDW-NU-",
+  "curve": "P384",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x00c7abf0e11eae510a523dfea08a09ff249f4ef663ca2189e3efc7c8c926ddc7c7988204a709cb3a4c8b6bbca1c9af19a62bbd6d99cf3db874f7679bcf732de443f0",
+        "y": "0x01d722f34101db0fbb572be2be9e249e84e1b30add486fa8e7e78e39f10ac8baef82a541624a47684a595de475864d56e36ca2457c74ce176949f0eb61f1e1d94897"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x008d5531a0916a503c12ab311d52306a5429b6e2639f0ee7f66d9c6ba52e04fb687897f04b9820b06b431e78cc875a5d30d8b0d0aa103bc9d3fef1912d9a20afe79f",
+        "y": "0x00a414b9f39792b5d1831ac04f839f1a3584f4f0a1fecee18811b3ebc245b1c28fa85a6cc29e66f34dafe7cafbb77ee9d13e3147e584672550d2acacc04784e7e9cc"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x0176a5f72774efead3cfc438567f6baeca616caa9b46fa519a34f424380640e5d97cf9c2243f6ac3cbbb3f8206ebf5a7b019aa232f0d0d92ae7516c60a3be304177e",
+        "y": "0x01f8b63621a68142c9d71505df4a6b955357c601990c2d653df3b80fec59f6db90fcf31cd19692bf6bed90341dbb5edd35e6190c749b458c930e75baaf789a505d97"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x00b40fabd637c16e814e432d55de94bbfe670b71372481b21b134d61e14b6b9eb58f01db1e429f78467dbdb0e445f76d0b1391d5fa0dca91406729254bccfa01a675",
+        "y": "0x01ea1d2ebb48dcc50ebe4c90567c4710a2c865de13e5b2932725db8866f9a2c6d1c0a07ec4a2fc89520ee27485209ca9228feaf53911e017193a96e5268d3338031c"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/P521-SHA512-SVDW-RO-.json
+++ b/poc/vectors/P521-SHA512-SVDW-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "P521-SHA512-SVDW-RO-",
+  "curve": "P384",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x00808273069f723fb5e1622925613603b6c9569a52a5f16da58c16ca8bc35d6ec2121cf33862a670737dcbe852a2c302e7676780373dc20113559bb6a07d97797bb2",
+        "y": "0x01c560c2616ccdbaf4c975fab1c704e4fc17b80f4a7427aaa351b5190d01bde1ea889ae1bf520792f01e637fc6edafa693142507e0b38d28f0fded6a1b2a24739050"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x01964afd0efa72b8a5d4a0a03b96d99829db27bbab8cf9f42d3652924b5a744afd37ce6eef4a0dda37772abe2b8b74d0e92a35a2314a54b2e9ff27767c26a85603c7",
+        "y": "0x005587e16e8eca460c26f687e4dc40e9c4db56d4bd921b0bf80b819dcc269622157a132ccb36bc5cb86c670af7b76b81eb6f637366ce353a97702bc067d9a49384ff"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x01a21f542f67faa88ea1a5b957296fe525bf944b59dfe36f9a59b9f4751857c65de7909b59df6ba95e4c1028fcd2027453be17f617477769fc7f7a84f3ca1ee29f06",
+        "y": "0x00b7b3302ca154e0164fcc5dd25bb95c2412b9c27d01edeac35f9ab8882a109465a1d63b1c5b592b06d335b3456d230c037dff595f5d71134c20516871a1f67957dc"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x017711a858081d58ec6a5a40c3c87331858ea22d4457f7dfb520030a235b1e607c8edb05e8ff0914ab383715f77329430d691603968f2f33af4f1daf4159ef598b42",
+        "y": "0x008701e21007e716be92492dd323e0b0c89b0831dd000e919bf59320dd283b77d05b176221b6e8fa1d1bb9d7e8d1fc41a7e06aff2980e3c46be4f08d05622b66b093"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/curve25519-SHA256-ELL2-NU-.json
+++ b/poc/vectors/curve25519-SHA256-ELL2-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "curve25519-SHA256-ELL2-NU-",
+  "curve": "curve25519",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x1bc629552c7309ff1067a5d939e34d7ce9441044d3e668f422f5905af9ddcd57",
+        "y": "0x12c0a351db894ea40a466702505156e63ef3ea2cb811226585c76f8f75c91849"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x0ce702dbd4a2314f58d7d57975ac52c370054cce8b565e231e00ddc914cccfd4",
+        "y": "0x6fdc3ceef868b31f9d82a2a68239233b7e5b1fcff30b1ce122aa2e68b1e5faf8"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x390e0b1546bac966312f2b15594db2a26576e3f7e5c9715dbc91b7199c1709a8",
+        "y": "0x5187330950f9036d9d354b9e63cde8f8a595c08981bc94a62526a5ebd5c58b7b"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x6ac9e338cb28298156054e85aaac3238080f5b9a6a7c3d81151193b796c739f3",
+        "y": "0x0b52f437b576db0c021098086276e0c9fd6346a6690de951605109eedf78250f"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/curve25519-SHA256-ELL2-RO-.json
+++ b/poc/vectors/curve25519-SHA256-ELL2-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "curve25519-SHA256-ELL2-RO-",
+  "curve": "curve25519",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x05d8b66cb4e80fca05b6301964875ab7d7c5a4c4918d547908708679fdeab67e",
+        "y": "0x22f61e41c8026936bcdfd52ea5435d1e014812f75fc05c0f08dd27c41b637f16"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x2bb2e2acc3c10db43c1e448d9c629cb8c096d04c39bd280b8607338a87f6786c",
+        "y": "0x3d08047945394b66b4dcf92b209e50a6fbc6cb33808ba3dc30c1295c2f85a838"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x34a14a92d7f8762ad298d4d9e8ffba22343a27cf34d00d2579756ccb78e49498",
+        "y": "0x36aa1ca1e20104f5ca0cd64ed21ca86299690ea49730a9205aee9d9cd778d92f"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x62815adb9f1240e8df44d28da17aa44f1a0031484d4e2fe91a8c798b68302b08",
+        "y": "0x153b6addc7bd52472a4b21bd92aed5da4cc46ce0ed54b2d90cd867da1e3581a6"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/curve25519-SHA512-ELL2-NU-.json
+++ b/poc/vectors/curve25519-SHA512-ELL2-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "curve25519-SHA512-ELL2-NU-",
+  "curve": "curve25519",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x58b8a19fa54fee896aac393ea2f5bb660cb506cf5bb65746373dabb35891400d",
+        "y": "0x30bbcb093784088e85427cf695591001ac168accd03e081db70752916cf3907b"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x2476ca2bca4673ae3232f782f4f531801e12d6b472bbacf8e6858231b40f98b9",
+        "y": "0x18a414d3d5b5b008555dfeedcba5042acab13cec7cb0966718b77b4b3a698653"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x234ea2d98a34839540cf5e0ec596013e31520bb3727ef89c224a421bcb433781",
+        "y": "0x3d0350ac09856c9d8ecda2bdd4747cf465993b3e2a87c105a0ed76ee66dd74c3"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x4191ffc13a5167131bf6a915063b440551f43a0705f7f325d79d815e7ea258d1",
+        "y": "0x67cd5c65a78ada97803361af386eb237142b71460b0e6e9a9121218a8827e7a3"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/curve25519-SHA512-ELL2-RO-.json
+++ b/poc/vectors/curve25519-SHA512-ELL2-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "curve25519-SHA512-ELL2-RO-",
+  "curve": "curve25519",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x50feb64dd1abff6d16b74995b3c1a0fafc7720a6008363a54d8c76d682adb0c3",
+        "y": "0x5d6a50b169d4b243a56a76b21d31644af542055804c4426daef4739dc60df9ff"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x73f8cf5ce558bbbbb96fc3029e5f1cda5ba8f01383bf2e3fcaa64e04e58207c0",
+        "y": "0x6f34d228d21099385e23db4e3c07de92af0f2018f1da6254354a0b85ea2f3035"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x7af277133abd633b5ad9ee05c9ec8478a45adb44c4ed3c44756d5e0945f5b994",
+        "y": "0x27564f28f1b14f10a1b0dc3fadb8a190f932430d24a75dc4b246d7300f899c3a"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x29689655ab6e08b1e7f003095c8025a85f1b8c912d678cf63cc05d078996a043",
+        "y": "0x0f512ce574d99ae0754b7c45dea16dec95876e548bf99412dc31af6e0ed55742"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/curve448-SHA512-ELL2-NU-.json
+++ b/poc/vectors/curve448-SHA512-ELL2-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "curve448-SHA512-ELL2-NU-",
+  "curve": "curve448",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x547e79a5b5f80ae8a6df960ff1b004549c9fcb3f441ea1fe87e0ec048dcc3fb5f03df8ba2bca1c65eb7a1fe999e7469bb968b00b5caa7926",
+        "y": "0xa2fce891d03e2d2eeefdd1b255077b986afbf1ffd96a034424e411a7e5760a8225245ba4d13d65adef4cb9a1403c3630a3edc4ffec0f53e8"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x16fbb0c1e4e268255eccc7b30693ca0a3abd1be0bb78cee7fd40991771e9ef0a3627de588dec2022b5c679fb457ac5507de561643a3fa5b6",
+        "y": "0xbc37cc0e912f1f78a361bde84fe8850b74611a09387156661f7432e4d344e68affcbb36d7a31ffa86aa0d2e0214cd259bba8fa74c946f2b6"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x9685c5869d5205b91c39229bf7b990364f351374a002207d479ad97cde92f6ceb95f069abe041b9d36943905ca51a8ec97638c296892f6a0",
+        "y": "0x619cc5b3387c67e1c491f74aee4bfe3eea027bfda909ce6544201646d84bcff0ab45847d6b216b36770fcb4ec48ddef1a7d3285a9de54028"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x824967182b013a3a233192c5e1f7b04ea14d2fad66f8079767379b69435662150b26b040414c7d121d164b4c20a90ac764c44519b78f511c",
+        "y": "0x7424780669506c2efaa36830418cb42fa3aa229afe0fbe1233df56c23a5698a0a1d48209718b29b5a3b31d259b6a3a8627ae24fab8492087"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/curve448-SHA512-ELL2-RO-.json
+++ b/poc/vectors/curve448-SHA512-ELL2-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "curve448-SHA512-ELL2-RO-",
+  "curve": "curve448",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x3e84104cc3cd307293aa996343784312c43c8d52c557b20c9d7e9f5a9a7688abde867cb07888365c7a2e5db4e92bc787c4ee8428568b6154",
+        "y": "0xd2ef35a217acd44cea256094faeb6de3f2857e395d2323967ae95229364864bd93b4251fb8e370337ba08b5af2c4638a9515d8e3ada90452"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x72bc0041edc0b82672479e983a31d2d09978ffacbd1ae97338f519b648269654242adac6304bfee01e2141f5df0ac5cbd820a98b5c8dbf71",
+        "y": "0x28f16c471ad01f4bcee68a964c2efc4b8fbfcafadf97ae5b3d8744b29fc66d8cd1e10858ecca53307d33b9d35b99efb05dc473cbdcd74a92"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0xcfdf709887c8fbaf1677e2ebca686d9763c0bf16a229ec489701c2e8c148e44ddf2b2f1bb41743f7ebe8303cac4a8e0836759fddbac7ef00",
+        "y": "0x180a0324630673a417c39a1ca60fb035463e8bb96f31b1673e5e3052c20ddc5eac3468dfc0282c91df8b5bd6255377a7b6534b20b90410fb"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x4cacc9137df7545739231a1790bdd65bce36eed0ff6b1b967e0b4335e20cc78350e1b3f0e573b28163a3d247aaee2bf763f8fe6458fe6957",
+        "y": "0x388e9e8e9fc6428a5deae8e6e5848a81c3f7c02418893826e5a6dcdf13acbe7b56ab7ff2f9b93f777d15dbbc04ffe210795bb37d880321ff"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/edwards25519-SHA256-EDELL2-NU-.json
+++ b/poc/vectors/edwards25519-SHA256-EDELL2-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "edwards25519-SHA256-EDELL2-NU-",
+  "curve": "edwards25519",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x1a791c829f260cccafa1fff2d5a6b4430abc42c719ea58691c41b281ed7be74e",
+        "y": "0x0b7f6203722b4fa867d24cf0c2b2897971fcfd78cac415b20574ec9e9ef4859d"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x0ae651dc37a7cf665b05223cad729d2da0d218bdbe831d83b1dcb673480a6679",
+        "y": "0x04215f51c5c609a846401c42c0cefa86d4e5a5662f236432eb9936f1a859075a"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x17590a72ebf483aaff7bbdf92e062567a8e0e5eedce8e7cd49a4a1749fb6d00b",
+        "y": "0x1d8cc55fad52dd30f5c1ac904b23337e345b91cb1c356d63b1fdbf1e9101da23"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x6559f1e3542dee41955c8ef7aaec38c4cd630a42980528bd8d3a22f695f1d7c6",
+        "y": "0x03dfc043dbaa5fdc64d47504ff6736dcccd0099f8ff94e4e7063f0d910e3b2ca"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/edwards25519-SHA256-EDELL2-RO-.json
+++ b/poc/vectors/edwards25519-SHA256-EDELL2-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "edwards25519-SHA256-EDELL2-RO-",
+  "curve": "edwards25519",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x7ca4a8ae6bc1fccae729407d6c1279692fb864b6d96bdca3a2c16ba2e24af09e",
+        "y": "0x329ae12d304d737d08478e995859cd9c7c979aa8bdb09bf4fedfa235e9826dbb"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x3941a4508fe43a19c9caeceb6cdc1ec729103ed345e8eef64fbae6bc9e60c915",
+        "y": "0x322178d97c6527ba12fd6605eb56ee89df7391cb2e6c3f23dfc428fd1a26324b"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x4817df27756180596c6e7053b2855ee5f6db197b30bac30e76890d92d143745c",
+        "y": "0x5a66af50d0dc5ca5cab764359654fb99041b63b817aef14161cf1ed0da079083"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x73dda005fcf673a511d685dbe96a7a584e2ec34e6031e12ce0fd55ef274a1c16",
+        "y": "0x7e71a68a8feb8e7f4f7599cb886ae63c099131a80caec0c232892e03a76d8c87"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/edwards25519-SHA512-EDELL2-NU-.json
+++ b/poc/vectors/edwards25519-SHA512-EDELL2-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "edwards25519-SHA512-EDELL2-NU-",
+  "curve": "edwards25519",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x2504cf3f92c7d2b7b169fbadbe82750f04fd25c9cc45aaa8996e457c7f7c95a9",
+        "y": "0x542b726d12d8368814d6be63593aef82b61027db7c5c543b20a75337a19bed13"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x5c407503d301871744a4c3761d261f4a30f72f4e4263cb02f734e4e833d58ac9",
+        "y": "0x3072a2c204a91dc25cf75b2bce2cf92c722bd51a049cbe4a535aecff5199939e"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x0cd736463d88679c68f81daa9cb39eea84fba186b39bf4d79f6954e45a6da4f4",
+        "y": "0x71c37b67f04f390658b8a568d916e4d3a8036b582d470f44371dd2c206c7b92b"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x48f70643c8878b4cdb32d6c8602a8b36c60de06ad174153a57f245e6d1cf7c5f",
+        "y": "0x763cadd8cdeca069e90d347133381112e60694ca1b72a3039637f993fc021279"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/edwards25519-SHA512-EDELL2-RO-.json
+++ b/poc/vectors/edwards25519-SHA512-EDELL2-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "edwards25519-SHA512-EDELL2-RO-",
+  "curve": "edwards25519",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x3b3cadfe248dce28c6a69b904c1fc0a898a8afe3f8c0615ba9303053c5db4030",
+        "y": "0x28cde14484d8a5fab9ae402ef50a0f20a27417700c598b7f254ec8296bbfeb6e"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x546e6baaefb4e96a91bd7a4e0fe3a3aad809165d374f417da084f327a34a977d",
+        "y": "0x1be187c1e8b69352a7da6d9c78011e1bcef6d022a8e3bab452c36667e6875871"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x368a024d1827bcd694119d1c851dadfb94d5b1946dcde9cc1bb754caa2cf1b34",
+        "y": "0x4788381d5082a1f0e98d871d06a850b24f0d16b0d03d8d5a894481044408f0ae"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x0a8001ba5a0bb00289e9790485fdeca05c0037d0554cf9c3708f6ff6304469c3",
+        "y": "0x11f2ba5581eb3d4a0314f1d58085068b0bf77e0d886bb32286f2c5ef1893e8a4"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/edwards448-SHA512-EDELL2-NU-.json
+++ b/poc/vectors/edwards448-SHA512-EDELL2-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "edwards448-SHA512-EDELL2-NU-",
+  "curve": "edwards448",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0xa0990d7cbfcfd9c1d7f3f41b9bd0c44b1de2b8b75fb71e4a0aa722fc6abb5e3aed7b90721be718f6a899d4b24413a9f556f2fd895e525261",
+        "y": "0xc0a5da1ebb46746d306962e1da17b2c0a424c258c82cc8e2e2f56bfda51cf563e6b4e88178ccde9b461115cea2894fef005bbde4d3361130"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x04ca29a5ba77f10660ef922fe267d5d50cd8befa425c16db55d21eaf8cd1af7f982d8164466d3d7b307f0555bbd5631d4eb8108e5d4093a5",
+        "y": "0x84b63197ac0cb623e2e421bb36e435d0cc8e7e402b6ec72634b87d578d418566a960412eb7a2a78704f7f615c0945d5ac7ea6cf44864721c"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0xb011b4edea151a4a4a347937d42bad8db0671b9959644c35bd525df0409372318e157034f6a853150808c929358ad8c5e02cf7625e911fb3",
+        "y": "0x14ff414c7d1327d7777949272ec897d3fb9daf9b40d4c4d1e01d4d146924bd8f5374d6911eec5ae0c01a850c2e7767eefaca50e96bcc265b"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x2b1170657e49262efff76530662972744f5648b387057ecc88e94171419ec2b285d680bc143cc56238c899096b3fb12b44b28e16e93156fc",
+        "y": "0xca9b738949fb396c14f1c5d3b6f00bd3434aaff5a30304788dbd5ca0000cd2c72cd65e3cbbfa4d24c4b3ee837ef30e794387fac3d61f350a"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/edwards448-SHA512-EDELL2-RO-.json
+++ b/poc/vectors/edwards448-SHA512-EDELL2-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "edwards448-SHA512-EDELL2-RO-",
+  "curve": "edwards448",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "Elligator2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x6da53e29c7595e8cf15b26a1929058819ed881ccea1e1b5646a439a95332503d4c910dabaed1ced36326c523777dff55c432294d9e1877ab",
+        "y": "0xf437749bc007c99472dbffc6c033d87cbf480cd745341c693054cbf9de4613a34e25e9bf0825407e118d20d6a710c50895a338117313e66b"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0xf36636027eac6ccc5fd9852c232ea09fb72a49856d161ff438ec79ed442609ebac8901b283a130259126bced9b83cca1ea6a2844ab354582",
+        "y": "0x1e33a01da62dcc774f0c9d3c84d1452687cb886bc386459892ecb7e586e820428f6c027cee3cce4a1676a3951b6e01eeee5086cc55cffc0a"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x94dd6004d2136149bfa588b7891421b5fa4f2ee6a7e1112aea2f10cad7ee220df37d55d03e568bbafe508ae7ad8519abe5f8824f16035a9f",
+        "y": "0x1dfd1f029f750a76f4f0258d3709c0b0290aee9a676cf493c00195f995b24fd71ce364b3e84de17012345d19e2d94d2e5e771fe0e6ed1d5f"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x961950c5b7fa9d39f9c626507c511bda19ca58bb232009438e78aa4935046a42d3eea408ae990009937b53f395b9fa6fdac53d0d481c5962",
+        "y": "0x3f82a2f77f21c3c797c3109b371428da866563f30a42a8e07c3c0921852ed65018882016ef1bc6dc90844ffe629816f9571f275322c5c9e1"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/secp256k1-SHA256-SSWU-NU-.json
+++ b/poc/vectors/secp256k1-SHA256-SSWU-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "secp256k1-SHA256-SSWU-NU-",
+  "curve": "secp256k1",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x904f6954413972669224203de8e54d59d1230d4805b486a5dfa9b666c4fe3e48",
+        "y": "0x052bec43422bce2786292416c2e318e642dffa93548b4b8419ce7fe6228434c0"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x194d0515ef2481fdc7308887949681ee4f48cb4cabaeea093adaad6c2bc83fa1",
+        "y": "0xe30e8d6c22c1b681daf297505c12d41f06105916b6ac0ef5dcdb4cf2a017134d"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x3cb9f09f266c6e6e3566c467aa83cea2a003f690c701d78b7297e3fda0916f84",
+        "y": "0x8fb1a9c506cca7bc47f2f48adf394f6d27d4c06839612151a369e2b7c9595c09"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x7ea4c8b7b1aed3683a3e896af7c7385ac5ebd601a47d9793bd3222f11438797a",
+        "y": "0x2b3e5d9881ce611632ecec860c639f076f27f919533b7635f8a678a9b84a1dd4"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/secp256k1-SHA256-SSWU-RO-.json
+++ b/poc/vectors/secp256k1-SHA256-SSWU-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "secp256k1-SHA256-SSWU-RO-",
+  "curve": "secp256k1",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SSWU",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0xdfa1e47a1709a9c0aef603332f20cf0671bfcf7662deb06eee60aa0af9e53a93",
+        "y": "0x614ca9fa9c2d24770dd2dbcb9c341b9897bab6ef4c467afb13cf3823e71e0bd7"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0xbd1f9b09539b5dd45b127ca245af68e53bda4715d25c4d1efd00e29f2b0064a2",
+        "y": "0xa887fa738003ee09eb119c5f494b328684960bc6169d2dc8c915cb1b75882864"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0xc8ff15c6cc5b9b855fad90aedefaf973f27ae0439f7cfd1f941f2cc5040d75fd",
+        "y": "0xff6c304fa5572e7a59d77fc21c06c80441d06fa7b514ec058fe8266cdc89d173"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0xb3373412ee87b85954109dcee8b5d91907eb9c76b20cb65ecc1a1a1a094a04c7",
+        "y": "0x3512b4e68d2b839ba86e9187648163dd7733670329e2db2624206e017b2880c2"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/secp256k1-SHA256-SVDW-NU-.json
+++ b/poc/vectors/secp256k1-SHA256-SVDW-NU-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "secp256k1-SHA256-SVDW-NU-",
+  "curve": "secp256k1",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0xf8315bda63051f996535ea97fbff227c8f3351726d60a0c66d4e51a39da5cedb",
+        "y": "0xe27e904c436ff289ce35c7182b21edc70b3c12f32b340074ef40f871c46f0059"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x7fd3bd788d6b594b09a184f15dea1b5cbf2eab71a641d2f4349037c3b732b9ad",
+        "y": "0x7a8181ea027e7272f9c6962dd949fca60489f453f7c2651d2109e35ca0570c0e"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x25775ff435ec7beff3f40eb9c1598d52bde1df5390663cd4f545d6b0d7a4ffee",
+        "y": "0xd09acf8e25b368982fe1c18358694d200a23302c1cd934bf49a68ad804c38dbb"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0xb242cc41bf25eaa6cd463019683104c732a7a273be824f101c2afa35378d3ff5",
+        "y": "0xbeaf35de4a7f9794bcbbeac771857fbfcf7835c18cc68450052159a95d86d81c"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/poc/vectors/secp256k1-SHA256-SVDW-RO-.json
+++ b/poc/vectors/secp256k1-SHA256-SVDW-RO-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "secp256k1-SHA256-SVDW-RO-",
+  "curve": "secp256k1",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
+  },
+  "hash": "sha256",
+  "map": {
+    "name": "SVDW",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0xc790ac0a3d22be9262cfeaaeaaa15e04e3c4832b54c06e58f109f3e91ae7852a",
+        "y": "0x2f404b8cd6fcd41be1027aeda290db73535d3d138ead378675aec532a439625b"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x6cf6cb890e6c0468cf51ab6965464b152f02dd98e32a8b4aa4191001b5d1f5e6",
+        "y": "0x70958c8c906dfcaf2e5e1ed15f8e6645f0d6729a396668d7dd43eb9b68a29be2"
+      },
+      "msg": "abc"
+    },
+    {
+      "P": {
+        "x": "0x1fceb825d86a3841b2c3fca0d7551cb1834d99525d27b41aa6f138b976b09bcb",
+        "y": "0xcab3ce2efcf3006d744d0c0271cf04610974529646e689784b98663b20e66580"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x181a293a091e084a9445ffbcf37add70e7812b045b8e41b36c844b4f89c835d8",
+        "y": "0x17b3f51f96a631c68e881d4147192ea705bcb320d3812563d3c9558c5793b45f"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}


### PR DESCRIPTION
It is re-based on top of #189 and #201 .

JSON test vectors for matching compatible implementations.

Example:
```json
{
  "ciphersuite": "P256-SHA256-SSWU-RO-",
  "curve": "P256",
  "dst": "QUUX-V01-CS02",
  "field": {
    "m": "0x1",
    "p": "0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff"
  },
  "hash": "sha256",
  "map": {
    "name": "SSWU",
    "sgn0": "sgn0_le"
  },
  "randomOracle": true,
  "vectors": [
    {
      "P": {
        "x": "0x8beb73a82ebeb6b400456f4da126aacbfa9b8049b71b250d2b7e4885b6b466bd",
        "y": "0x15826dc578f4fbc1ac5fc3f9e15da3ece18be914f332bce8ce5bf1371805d149"
      },
      "msg": ""
    },
 ]
}
```