### PR TITLE
tiny build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ report.xml
 venv/
 lib
 draft-irtf-cfrg-hash-to-curve.xml
+metadata.min.js

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -921,6 +921,7 @@ informative:
   W19:
     title: An explicit, generic parameterization for the Shallue--van de Woestijne map
     target: https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve/doc/svdw_params.pdf
+    date: 2019
     author:
       -
         ins: R. S. Wahby


### PR DESCRIPTION
The new version of xml2rfc doesn't like empty dates, and something has started dumping out an empty metadata.min.js file.

Fix empty date, add metadata.min.js to .gitignore.