### PR TITLE
new hash_to_field definition

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2448,6 +2448,7 @@ Each suite comprises the following parameters:
 - E, the target elliptic curve over a field F.
 - p, the characteristic of the field F.
 - m, the extension degree of the field F.
+- k, the target security level of the suite in bits.
 - sgn0, one of the variants specified in {{sgn0-variants}}.
 - L, the length parameter for hash\_to\_field ({{hashtofield-sec}}).
 - expand\_message, one of the variants specified in {{hashtofield-expand}}
@@ -2491,6 +2492,7 @@ P256-XMD:SHA.256-SSWU-RO- is defined as follows:
    - B = 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b
 - p: 2^256 - 2^224 + 2^192 + 2^96 - 1
 - m: 1
+- k: 128
 - sgn0: sgn0\_le ({{sgn0-le}})
 - expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-256
@@ -2526,6 +2528,7 @@ P384-XMD:SHA.512-SSWU-RO- is defined as follows:
   - B = 0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef
 - p: 2^384 - 2^128 - 2^96 + 2^32 - 1
 - m: 1
+- k: 192
 - sgn0: sgn0\_le ({{sgn0-le}})
 - expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-512
@@ -2561,6 +2564,7 @@ P521-XMD:SHA.512-SSWU-RO- is defined as follows:
   - B = 0x51953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00
 - p: 2^521 - 1
 - m: 1
+- k: 256
 - sgn0: sgn0\_le ({{sgn0-le}})
 - expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-512
@@ -2596,6 +2600,7 @@ curve25519-XMD:SHA.256-ELL2-RO- is defined as follows:
   - K = 1
 - p: 2^255 - 19
 - m: 1
+- k: 128
 - sgn0: sgn0\_le ({{sgn0-le}})
 - expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-256
@@ -2647,6 +2652,7 @@ curve448-XMD:SHA.512-ELL2-RO- is defined as follows:
   - K = 1
 - p: 2^448 - 2^224 - 1
 - m: 1
+- k: 224
 - sgn0: sgn0\_le ({{sgn0-le}})
 - expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-512
@@ -2684,6 +2690,7 @@ secp256k1-XMD:SHA.256-SSWU-RO- is defined as follows:
 - E: y^2 = x^3 + 7
 - p: 2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1
 - m: 1
+- k: 128
 - sgn0: sgn0\_le ({{sgn0-le}})
 - expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-256
@@ -2726,6 +2733,7 @@ BLS12381G1-XMD:SHA.256-SSWU-RO- is defined as follows:
 - E: y^2 = x^3 + 4
 - p: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
 - m: 1
+- k: 128
 - sgn0: sgn0\_be ({{sgn0-be}})
 - expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-256
@@ -2770,6 +2778,7 @@ BLS12381G2-XMD:SHA.256-SSWU-RO- is defined as follows:
   - p: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
   - m: 2
   - (1, I) is the basis for F, where I^2 + 1 == 0 in F
+- k: 128
 - sgn0: sgn0\_be ({{sgn0-be}})
 - expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-256
@@ -2804,7 +2813,8 @@ Budroni and Pintore ({{BP18}}, Section 4.1).
 
 The RECOMMENDED way to define a new hash-to-curve suite is:
 
-1. E, F, p, and m are determined by the elliptic curve and its base field.
+1. E, F, p, and m are determined by the elliptic curve and its base field;
+   k is determined by the security level of the elliptic curve.
 
 2. Choose encoding type, either hash\_to\_curve or encode\_to\_curve ({{roadmap}}).
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2910,6 +2910,11 @@ This document has no IANA actions.
 When constant-time implementations are required, all basic operations and
 utility functions must be implemented in constant time, as discussed in
 {{utility}}.
+In some applications (e.g., embedded systems), leakage through other side
+channels (e.g., power or electromagnetic side channels) may be pertinent.
+Defending against such leakage is outside the scope of this document, because
+the nature of the leakage and the appropriate defense depends on the protocol
+from which a hash-to-curve function is invoked.
 
 Each encoding function accepts arbitrary input and maps it to a pseudorandom
 point on the curve.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2442,9 +2442,9 @@ points on a specific elliptic curve group.
 Each suite comprises the following parameters:
 
 - Suite ID, a short name used to refer to a given suite.
-  The ID also indicates whether a suite is a random oracle or nonuniform
-  encoding ({{term-rom}}, {{roadmap}}).
   {{suiteIDformat}} discusses the naming conventions for suite IDs.
+- encoding type, either random oracle (hash\_to\_curve) or nonuniform (encode\_to\_curve).
+  See {{roadmap}} for definitions of these encoding types.
 - E, the target elliptic curve over a field F.
 - p, the characteristic of the field F.
 - m, the extension degree of the field F.
@@ -2461,10 +2461,10 @@ additional parameters Z, M, rational\_map, E', and/or iso\_map.
 These MUST be specified when applicable.
 
 All applications MUST choose a domain separation tag (DST)
-for use with hash\_to\_field ({{hashtofield}}), in accordance with the
-guidelines of {{domain-separation}}.
-In addition, applications whose security requires a random oracle MUST use
-a suite specifying hash\_to\_curve ({{roadmap}}); see {{suiteIDformat}}.
+in accordance with the guidelines in {{domain-separation}}.
+In addition, applications whose security requires a random oracle
+that returns points on the target curve MUST use a suite whose
+encoding type is hash\_to\_curve ({{roadmap}}); see {{suiteIDformat}}.
 
 The below table lists the curves for which suites are defined and
 the subsection that gives the corresponding parameters.
@@ -2479,13 +2479,334 @@ the subsection that gives the corresponding parameters.
 | secp256k1                 | {{suites-secp256k1}} |
 | BLS12-381                 | {{suites-bls12381}}  |
 
+## Suites for NIST P-256 {#suites-p256}
+
+This section defines ciphersuites for the NIST P-256 elliptic curve {{FIPS186-4}}.
+
+P256-XMD:SHA.256-SSWU-RO- is defined as follows:
+
+- encoding type: hash\_to\_curve ({{roadmap}})
+- E: y^2 = x^3 + A * x + B, where
+   - A = -3
+   - B = 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b
+- p: 2^256 - 2^224 + 2^192 + 2^96 - 1
+- m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
+- H: SHA-256
+- L: 48
+- f: Simplified SWU method, {{simple-swu}}
+- Z: -10
+- h\_eff: 1
+
+P256-XMD:SHA.256-SVDW-RO- is identical to P256-XMD:SHA.256-SSWU-RO-,
+except for the following parameters:
+
+- f: Shallue-van de Woestijne method, {{svdw}}
+- Z: -3
+
+P256-XMD:SHA.256-SSWU-NU- is identical to P256-XMD:SHA.256-SSWU-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+P256-XMD:SHA.256-SVDW-NU- is identical to P256-XMD:SHA.256-SVDW-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+An optimized example implementation of the Simplified SWU mapping
+to P-256 is given in {{sswu-map-to-3mod4}}.
+
+## Suites for NIST P-384 {#suites-p384}
+
+This section defines ciphersuites for the NIST P-384 elliptic curve {{FIPS186-4}}.
+
+P384-XMD:SHA.512-SSWU-RO- is defined as follows:
+
+- encoding type: hash\_to\_curve ({{roadmap}})
+- E: y^2 = x^3 + A * x + B, where
+  - A = -3
+  - B = 0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef
+- p: 2^384 - 2^128 - 2^96 + 2^32 - 1
+- m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
+- H: SHA-512
+- L: 72
+- f: Simplified SWU method, {{simple-swu}}
+- Z: -12
+- h\_eff: 1
+
+P384-XMD:SHA.512-SVDW-RO- is identical to P384-XMD:SHA.512-SSWU-RO-,
+except for the following parameters:
+
+- f: Shallue-van de Woestijne method, {{svdw}}
+- Z: -1
+
+P384-XMD:SHA.512-SSWU-NU- is identical to P384-XMD:SHA.512-SSWU-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+P384-XMD:SHA.512-SVDW-NU- is identical to P384-XMD:SHA.512-SVDW-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+An optimized example implementation of the Simplified SWU mapping
+to P-384 is given in {{sswu-map-to-3mod4}}.
+
+## Suites for NIST P-521 {#suites-p521}
+
+This section defines ciphersuites for the NIST P-521 elliptic curve {{FIPS186-4}}.
+
+P521-XMD:SHA.512-SSWU-RO- is defined as follows:
+
+- encoding type: hash\_to\_curve ({{roadmap}})
+- E: y^2 = x^3 + A * x + B, where
+  - A = -3
+  - B = 0x51953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00
+- p: 2^521 - 1
+- m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
+- H: SHA-512
+- L: 96
+- f: Simplified SWU method, {{simple-swu}}
+- Z: -4
+- h\_eff: 1
+
+P521-XMD:SHA.512-SVDW-RO- is identical to P521-XMD:SHA.512-SSWU-RO-,
+except for the following parameters:
+
+- f: Shallue-van de Woestijne method, {{svdw}}
+- Z: 1
+
+P521-XMD:SHA.512-SSWU-NU- is identical to P512-XMD:SHA.512-SSWU-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+P521-XMD:SHA.512-SVDW-NU- is identical to P512-XMD:SHA.512-SVDW-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+An optimized example implementation of the Simplified SWU mapping
+to P-521 is given in {{sswu-map-to-3mod4}}.
+
+## Suites for curve25519 and edwards25519 {#suites-25519}
+
+This section defines ciphersuites for curve25519 and edwards25519 {{RFC7748}}.
+
+curve25519-XMD:SHA.256-ELL2-RO- is defined as follows:
+
+- encoding type: hash\_to\_curve ({{roadmap}})
+- E: K * t^2 = s^3 + J * s^2 + s, where
+  - J = 486662
+  - K = 1
+- p: 2^255 - 19
+- m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
+- H: SHA-256
+- L: 48
+- f: Elligator 2 method, {{elligator2}}
+- Z: 2
+- h\_eff: 8
+
+edwards25519-XMD:SHA.256-ELL2-RO- is identical to curve25519-XMD:SHA.256-ELL2-RO-,
+except for the following parameters:
+
+- E: a * v^2 + w^2 = 1 + d * v^2 * w^2, where
+  - a = -1
+  - d = 0x52036cee2b6ffe738cc740797779e89800700a4d4141d8ab75eb4dca135978a3
+- f: Twisted Edwards Elligator 2 method, {{ell2edwards}}
+- M: curve25519 defined in {{RFC7748}}, Section 4.1
+- rational\_map: the birational map defined in {{RFC7748}}, Section 4.1
+
+curve25519-XMD:SHA.256-ELL2-NU- is identical to curve25519-XMD:SHA.256-ELL2-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+edwards25519-XMD:SHA.256-ELL2-NU- is identical to edwards25519-XMD:SHA.256-ELL2-RO-,
+except that ene encoding type is encode\_to\_curve ({{roadmap}}).
+
+curve25519-XMD:SHA.512-ELL2-RO- is identical to curve25519-XMD:SHA.256-ELL2-RO-,
+except that H is SHA-512.
+
+curve25519-XMD:SHA.512-ELL2-NU- is identical to curve25519-XMD:SHA.256-ELL2-NU-,
+except that H is SHA-512.
+
+edwards25519-XMD:SHA.512-ELL2-RO- is identical to edwards25519-XMD:SHA.256-ELL2-RO-,
+except that H is SHA-512.
+
+edwards25519-XMD:SHA.512-ELL2-NU- is identical to edwards25519-XMD:SHA.256-ELL2-NU-;
+except that H is SHA-512.
+
+Optimized example implementations of the above mappings are given in
+{{map-to-curve25519}} and {{map-to-edwards25519}}.
+
+## Suites for curve448 and edwards448 {#suites-448}
+
+This section defines ciphersuites for curve448 and edwards448 {{RFC7748}}.
+
+curve448-XMD:SHA.512-ELL2-RO- is defined as follows:
+
+- encoding type: hash\_to\_curve ({{roadmap}})
+- E: K * t^2 = s^3 + J * s^2 + s, where
+  - J = 156326
+  - K = 1
+- p: 2^448 - 2^224 - 1
+- m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
+- H: SHA-512
+- L: 84
+- f: Elligator 2 method, {{elligator2}}
+- Z: -1
+- h\_eff: 4
+
+edwards448-XMD:SHA.512-ELL2-RO- is identical to curve448-XMD:SHA.512-ELL2-RO-,
+except for the following parameters:
+
+- E: a * v^2 + w^2 = 1 + d * v^2 * w^2, where
+  - a = 1
+  - d = -39081
+- f: Twisted Edwards Elligator 2 method, {{ell2edwards}}
+- M: curve448, defined in {{RFC7748}}, Section 4.2
+- rational\_map: the 4-isogeny map defined in {{RFC7748}}, Section 4.2
+
+curve448-XMD:SHA.512-ELL2-NU- is identical to curve448-XMD:SHA.512-ELL2-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+edwards448-XMD:SHA.512-ELL2-NU- is identical to edwards448-XMD:SHA.512-ELL2-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+Optimized example implementations of the above mappings are given in
+{{map-to-curve448}} and {{map-to-edwards448}}.
+
+## Suites for secp256k1 {#suites-secp256k1}
+
+This section defines ciphersuites for the secp256k1 elliptic curve {{SEC2}}.
+
+secp256k1-XMD:SHA.256-SSWU-RO- is defined as follows:
+
+- encoding type: hash\_to\_curve ({{roadmap}})
+- E: y^2 = x^3 + 7
+- p: 2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1
+- m: 1
+- sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
+- H: SHA-256
+- L: 48
+- f: Simplified SWU for AB == 0, {{simple-swu-AB0}}
+- Z: -11
+- E': y'^2 = x'^3 + A' * x' + B', where
+  - A': 0x3f8731abdd661adca08a5558f0f5d272e953d363cb6f0e5d405447c01a444533
+  - B': 1771
+- iso\_map: the 3-isogeny map from E' to E given in {{appx-iso-secp256k1}}
+- h\_eff: 1
+
+secp256k1-XMD:SHA.256-SVDW-RO- is identical to secp256k1-XMD:SHA.256-SSWU-RO-,
+except for the following parameters:
+
+- f: Shallue-van de Woestijne method, {{svdw}}
+- Z: 1
+- E' is not defined for this suite
+- iso\_map is not defined for this suite
+
+secp256k1-XMD:SHA.256-SSWU-NU- is identical to secp256k1-XMD:SHA.256-SSWU-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+secp256k1-XMD:SHA.256-SVDW-NU- is identical to secp256k1-XMD:SHA.256-SVDW-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+An optimized example implementation of the Simplified SWU mapping
+to the curve E' isogenous to secp256k1 is given in {{sswu-map-to-3mod4}}.
+
+## Suites for BLS12-381 {#suites-bls12381}
+
+This section defines ciphersuites for groups G1 and G2 of
+the BLS12-381 elliptic curve {{BLS12-381}}.
+
+### BLS12-381 G1 {#suites-bls12381-g1}
+
+BLS12381G1-XMD:SHA.256-SSWU-RO- is defined as follows:
+
+- encoding type: hash\_to\_curve ({{roadmap}})
+- E: y^2 = x^3 + 4
+- p: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+- m: 1
+- sgn0: sgn0\_be ({{sgn0-be}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
+- H: SHA-256
+- L: 64
+- f: Simplified SWU for AB == 0, {{simple-swu-AB0}}
+- Z: 11
+- E': y'^2 = x'^3 + A' * x' + B', where
+  - A' = 0x144698a3b8e9433d693a02c96d4982b0ea985383ee66a8d8e8981aefd881ac98936f8da0e0f97f5cf428082d584c1d
+  - B' = 0x12e2908d11688030018b12e8753eee3b2016c1f0f24f4070a0b9c14fcef35ef55a23215a316ceaa5d1cc48e98e172be0
+- iso\_map: the 11-isogeny map from E' to E given in {{appx-iso-bls12381-g1}}
+- h\_eff: 0xd201000000010001
+
+BLS12381G1-XMD:SHA.256-SVDW-RO- is identical to BLS12381G1-XMD:SHA.256-SSWU-RO-,
+except for the following parameters:
+
+- f: Shallue-van de Woestijne method, {{svdw}}
+- Z: -3
+- E' is not defined for this suite
+- iso\_map is not defined for this suite
+
+BLS12381G1-XMD:SHA.256-SSWU-NU- is identical to BLS12381G1-XMD:SHA.256-SSWU-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+BLS12381G1-XMD:SHA.256-SVDW-NU- is identical to BLS12381G1-XMD:SHA.256-SVDW-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+Note that the h\_eff values for these suites are chosen for compatibility
+with the fast cofactor clearing method described by Scott ({{WB19}} Section 5).
+
+An optimized example implementation of the Simplified SWU mapping
+to the curve E' isogenous to BLS12-381 G1 is given in {{sswu-map-to-3mod4}}.
+
+### BLS12-381 G2 {#suites-bls12381-g2}
+
+Group G2 of BLS12-381 is defined over a field F = GF(p^m) defined as:
+
+BLS12381G2-XMD:SHA.256-SSWU-RO- is defined as follows:
+
+- encoding type: hash\_to\_curve ({{roadmap}})
+- E: y^2 = x^3 + 4 * (1 + I)
+- base field F is GF(p^m), where
+  - p: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+  - m: 2
+  - (1, I) is the basis for F, where I^2 + 1 == 0 in F
+- sgn0: sgn0\_be ({{sgn0-be}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
+- H: SHA-256
+- L: 64
+- f: Simplified SWU for AB == 0, {{simple-swu-AB0}}
+- Z: -(2 + I)
+- E': y'^2 = x'^3 + A' * x' + B', where
+  - A' = 240 * I
+  - B' = 1012 * (1 + I)
+- iso\_map: the isogeny map from E' to E given in {{appx-iso-bls12381-g2}}
+- h\_eff: 0xbc69f08f2ee75b3584c6a0ea91b352888e2a8e9145ad7689986ff031508ffe1329c2f178731db956d82bf015d1212b02ec0ec69d7477c1ae954cbc06689f6a359894c0adebbf6b4e8020005aaa95551
+
+BLS12381G2-XMD:SHA.256-SVDW-RO- is identical to BLS12381G2-XMD:SHA.256-SSWU-RO-,
+except for the following parameters:
+
+- f: Shallue-van de Woestijne method, {{svdw}}
+- Z: I
+- E' is not defined for this suite
+- iso\_map is not defined for this suite
+
+BLS12381G2-XMD:SHA.256-SSWU-NU- is identical to BLS12381G2-XMD:SHA.256-SSWU-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+BLS12381G2-XMD:SHA.256-SVDW-NU- is identical to BLS12381G2-XMD:SHA.256-SVDW-RO-,
+except that the encoding type is encode\_to\_curve ({{roadmap}}).
+
+Note that the h\_eff values for these suites are chosen for compatibility
+with the fast cofactor clearing method described by
+Budroni and Pintore ({{BP18}}, Section 4.1).
+
 ## Defining a new hash-to-curve suite {#new-suite}
 
 The RECOMMENDED way to define a new hash-to-curve suite is:
 
 1. E, F, p, and m are determined by the elliptic curve and its base field.
 
-2. Choose either hash\_to\_curve or encode\_to\_curve ({{roadmap}}).
+2. Choose encoding type, either hash\_to\_curve or encode\_to\_curve ({{roadmap}}).
 
 3. Choose a sgn0 variant following the guidelines in {{sgn0-variants}}.
 
@@ -2569,291 +2890,6 @@ Fields MUST be chosen as follows:
     For example, "RO:V02" is an appropriate ENC\_VAR value for the second
     version of a random-oracle suite, while "RO:V02:FOO01:BAR17" might be
     used to indicate a variant of that suite.
-
-## Suites for NIST P-256 {#suites-p256}
-
-This section defines ciphersuites for the NIST P-256 elliptic curve {{FIPS186-4}}.
-
-The suites P256-XMD:SHA.256-SSWU-RO- and P256-XMD:SHA.256-SSWU-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Simplified SWU method, {{simple-swu}}
-- Z: -10
-
-The suites P256-XMD:SHA.256-SVDW-RO- and P256-XMD:SHA.256-SVDW-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Shallue-van de Woestijne method, {{svdw}}
-- Z: -3
-
-The common parameters for the above suites are:
-
-- E: y^2 = x^3 + A * x + B, where
-   - A = -3
-   - B = 0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b
-- p: 2^256 - 2^224 + 2^192 + 2^96 - 1
-- m: 1
-- sgn0: sgn0\_le ({{sgn0-le}})
-- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
-- H: SHA-256
-- L: 48
-- h\_eff: 1
-
-An optimized example implementation of the Simplified SWU mapping
-to P-256 is given in {{sswu-map-to-3mod4}}.
-
-## Suites for NIST P-384 {#suites-p384}
-
-This section defines ciphersuites for the NIST P-384 elliptic curve {{FIPS186-4}}.
-
-The suites P384-XMD:SHA.512-SSWU-RO- and P384-XMD:SHA.512-SSWU-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Simplified SWU method, {{simple-swu}}
-- Z: -12
-
-The suites P384-XMD:SHA.512-SVDW-RO- and P384-XMD:SHA.512-SVDW-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Shallue-van de Woestijne method, {{svdw}}
-- Z: -1
-
-The common parameters for the above suites are:
-
-- E: y^2 = x^3 + A * x + B, where
-  - A = -3
-  - B = 0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef
-- p: 2^384 - 2^128 - 2^96 + 2^32 - 1
-- m: 1
-- sgn0: sgn0\_le ({{sgn0-le}})
-- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
-- H: SHA-512
-- L: 72
-- h\_eff: 1
-
-An optimized example implementation of the Simplified SWU mapping
-to P-384 is given in {{sswu-map-to-3mod4}}.
-
-## Suites for NIST P-521 {#suites-p521}
-
-This section defines ciphersuites for the NIST P-521 elliptic curve {{FIPS186-4}}.
-
-The suites P521-XMD:SHA.512-SSWU-RO- and P521-XMD:SHA.512-SSWU-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Simplified SWU method, {{simple-swu}}
-- Z: -4
-
-The suites P521-XMD:SHA.512-SVDW-RO- and P521-XMD:SHA.512-SVDW-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Shallue-van de Woestijne method, {{svdw}}
-- Z: 1
-
-The common parameters for the above suites are:
-
-- E: y^2 = x^3 + A * x + B, where
-  - A = -3
-  - B = 0x51953eb9618e1c9a1f929a21a0b68540eea2da725b99b315f3b8b489918ef109e156193951ec7e937b1652c0bd3bb1bf073573df883d2c34f1ef451fd46b503f00
-- p: 2^521 - 1
-- m: 1
-- sgn0: sgn0\_le ({{sgn0-le}})
-- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
-- H: SHA-512
-- L: 96
-- h\_eff: 1
-
-An optimized example implementation of the Simplified SWU mapping
-to P-521 is given in {{sswu-map-to-3mod4}}.
-
-## Suites for curve25519 and edwards25519 {#suites-25519}
-
-This section defines ciphersuites for curve25519 and edwards25519 {{RFC7748}}.
-
-The suites curve25519-XMD:SHA.256-ELL2-RO- and curve25519-XMD:SHA.256-ELL2-NU-
-share the following parameters, in addition to the common parameters below.
-
-- E: K * t^2 = s^3 + J * s^2 + s, where
-  - J = 486662
-  - K = 1
-- f: Elligator 2 method, {{elligator2}}
-
-The suites edwards25519-XMD:SHA.256-ELL2-RO- and edwards25519-XMD:SHA.256-ELL2-NU-
-share the following parameters, in addition to the common parameters below.
-
-- E: a * v^2 + w^2 = 1 + d * v^2 * w^2, where
-  - a = -1
-  - d = 0x52036cee2b6ffe738cc740797779e89800700a4d4141d8ab75eb4dca135978a3
-- f: Twisted Edwards Elligator 2 method, {{ell2edwards}}
-- M: curve25519 defined in {{RFC7748}}, Section 4.1
-- rational\_map: the birational map defined in {{RFC7748}}, Section 4.1
-
-The common parameters for all of the above suites are:
-
-- p: 2^255 - 19
-- m: 1
-- sgn0: sgn0\_le ({{sgn0-le}})
-- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
-- H: SHA-256
-- L: 48
-- Z: 2
-- h\_eff: 8
-
-The suites curve25519-XMD:SHA.512-ELL2-RO-, curve25519-XMD:SHA.512-ELL2-NU-,
-edwards25519-XMD:SHA.512-ELL2-RO-, and edwards25519-XMD:SHA.512-ELL2-NU-
-are identical to the correspondingly named suites defined above,
-except that H is SHA-512.
-
-Optimized example implementations of the above mappings are given in
-{{map-to-curve25519}} and {{map-to-edwards25519}}.
-
-## Suites for curve448 and edwards448 {#suites-448}
-
-This section defines ciphersuites for curve448 and edwards448 {{RFC7748}}.
-
-The suites curve448-XMD:SHA.512-ELL2-RO- and curve448-XMD:SHA.512-ELL2-NU-
-share the following parameters, in addition to the common parameters below.
-
-- E: K * t^2 = s^3 + J * s^2 + s, where
-  - J = 156326
-  - K = 1
-- f: Elligator 2 method, {{elligator2}}
-
-The suites edwards448-XMD:SHA.512-ELL2-RO- and edwards448-XMD:SHA.512-ELL2-NU-
-share the following parameters, in addition to the common parameters below.
-
-- E: a * v^2 + w^2 = 1 + d * v^2 * w^2, where
-  - a = 1
-  - d = -39081
-- f: Twisted Edwards Elligator 2 method, {{ell2edwards}}
-- M: curve448, defined in {{RFC7748}}, Section 4.2
-- rational\_map: the 4-isogeny map defined in {{RFC7748}}, Section 4.2
-
-The common parameters for all of the above suites are:
-
-- p: 2^448 - 2^224 - 1
-- m: 1
-- sgn0: sgn0\_le ({{sgn0-le}})
-- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
-- H: SHA-512
-- L: 84
-- Z: -1
-- h\_eff: 4
-
-Optimized example implementations of the above mappings are given in
-{{map-to-curve448}} and {{map-to-edwards448}}.
-
-## Suites for secp256k1 {#suites-secp256k1}
-
-This section defines ciphersuites for the secp256k1 elliptic curve {{SEC2}}.
-
-The suites secp256k1-XMD:SHA.256-SSWU-RO- and secp256k1-XMD:SHA.256-SSWU-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Simplified SWU for AB == 0, {{simple-swu-AB0}}
-- Z: -11
-- E': y'^2 = x'^3 + A' * x' + B', where
-  - A': 0x3f8731abdd661adca08a5558f0f5d272e953d363cb6f0e5d405447c01a444533
-  - B': 1771
-- iso\_map: the 3-isogeny map from E' to E given in {{appx-iso-secp256k1}}
-
-The suites secp256k1-XMD:SHA.256-SVDW-RO- and secp256k1-XMD:SHA.256-SVDW-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Shallue-van de Woestijne method, {{svdw}}
-- Z: 1
-
-The common parameters for all of the above suites are:
-
-- E: y^2 = x^3 + 7
-- p: 2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1
-- m: 1
-- sgn0: sgn0\_le ({{sgn0-le}})
-- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
-- H: SHA-256
-- L: 48
-- h\_eff: 1
-
-An optimized example implementation of the Simplified SWU mapping
-to the curve E' isogenous to secp256k1 is given in {{sswu-map-to-3mod4}}.
-
-## Suites for BLS12-381 {#suites-bls12381}
-
-This section defines ciphersuites for groups G1 and G2 of
-the BLS12-381 elliptic curve {{BLS12-381}}.
-
-### BLS12-381 G1 {#suites-bls12381-g1}
-
-The suites BLS12381G1-XMD:SHA.256-SSWU-RO- and BLS12381G1-XMD:SHA.256-SSWU-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Simplified SWU for AB == 0, {{simple-swu-AB0}}
-- Z: 11
-- E': y'^2 = x'^3 + A' * x' + B', where
-  - A' = 0x144698a3b8e9433d693a02c96d4982b0ea985383ee66a8d8e8981aefd881ac98936f8da0e0f97f5cf428082d584c1d
-  - B' = 0x12e2908d11688030018b12e8753eee3b2016c1f0f24f4070a0b9c14fcef35ef55a23215a316ceaa5d1cc48e98e172be0
-- iso\_map: the 11-isogeny map from E' to E given in {{appx-iso-bls12381-g1}}
-
-The suites BLS12381G1-XMD:SHA.256-SVDW-RO- and BLS12381G1-XMD:SHA.256-SVDW-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Shallue-van de Woestijne method, {{svdw}}
-- Z: -3
-
-The common parameters for the above suites are:
-
-- E: y^2 = x^3 + 4
-- p: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
-- m: 1
-- sgn0: sgn0\_be ({{sgn0-be}})
-- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
-- H: SHA-256
-- L: 64
-- h\_eff: 0xd201000000010001
-
-Note that this h\_eff value is chosen for compatibility
-with the fast cofactor clearing method described by Scott ({{WB19}} Section 5).
-
-An optimized example implementation of the Simplified SWU mapping
-to the curve E' isogenous to BLS12-381 G1 is given in {{sswu-map-to-3mod4}}.
-
-### BLS12-381 G2 {#suites-bls12381-g2}
-
-Group G2 of BLS12-381 is defined over a field F = GF(p^m) defined as:
-
-- p: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
-- m: 2
-- (1, I) is the basis for F, where I^2 + 1 == 0 in F
-
-The suites BLS12381G2-XMD:SHA.256-SSWU-RO- and BLS12381G2-XMD:SHA.256-SSWU-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Simplified SWU for AB == 0, {{simple-swu-AB0}}
-- Z: -(2 + I)
-- E': y'^2 = x'^3 + A' * x' + B', where
-  - A' = 240 * I
-  - B' = 1012 * (1 + I)
-- iso\_map: the isogeny map from E' to E given in {{appx-iso-bls12381-g2}}
-
-The suites BLS12381G2-XMD:SHA.256-SVDW-RO- and BLS12381G2-XMD:SHA.256-SVDW-NU-
-share the following parameters, in addition to the common parameters below.
-
-- f: Shallue-van de Woestijne method, {{svdw}}
-- Z: I
-
-The common parameters for the above suites are:
-
-- E: y^2 = x^3 + 4 * (1 + I)
-- p, m, F: defined above
-- sgn0: sgn0\_be ({{sgn0-be}})
-- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
-- H: SHA-256
-- L: 64
-- h\_eff: 0xbc69f08f2ee75b3584c6a0ea91b352888e2a8e9145ad7689986ff031508ffe1329c2f178731db956d82bf015d1212b02ec0ec69d7477c1ae954cbc06689f6a359894c0adebbf6b4e8020005aaa95551
-
-Note that this h\_eff value is chosen for compatibility
-with the fast cofactor clearing method described by
-Budroni and Pintore ({{BP18}}, Section 4.1).
 
 # IANA Considerations
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1702,8 +1702,8 @@ Notation:
 
 Steps:
 1. ell = ceil((len_in_octets + k_in_octets) / b_in_octets)
-2. ABORT if ell > 255
-3. b_0 = H(DST || I2OSP(0, 1) || I2OSP(ell, 1) || msg)
+2. ABORT if ell > 256
+3. b_0 = H(DST || I2OSP(0, 1) || I2OSP(len_in_octets, 2) || msg)
 4. for i in (1, ..., ell - 1):
 5.   b_i = H(DST || I2OSP(i, 1) || b_(i - 1))
 6. b_0_chopped = b_0[0 : (b_in_octets - k_in_octets)]

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1768,6 +1768,13 @@ primitive, whereas a Mersenne twister pseudorandom number generator is not.
 
 - MUST give independent values for distinct (msg, DST, length) inputs.
 
+- MUST use the domain separation tag DST to ensure that invocations of
+cryptographic primitives inside of expand\_message are domain separated
+from all invocations outside of expand\_message.
+For example, if the expand\_message variant uses a hash function H, DST
+MUST be either prepended or appended to the input to each invocation of H
+(for consistency, prepending is the RECOMMENDED approach).
+
 - SHOULD read msg exactly once, for efficiency when msg is long.
 
 In addition, an expand\_message variant MUST specify a unique EXP\_TAG
@@ -2916,22 +2923,16 @@ Defending against such leakage is outside the scope of this document, because
 the nature of the leakage and the appropriate defense depends on the protocol
 from which a hash-to-curve function is invoked.
 
-Each encoding function accepts arbitrary input and maps it to a pseudorandom
-point on the curve.
-Directly evaluating the mappings of {{mappings}} produces an output that is
-distinguishable from random.
-{{roadmap}} shows how to use these mappings to construct hash\_to\_curve, which is
-indifferentiable from a random oracle.
+Each encoding variant ({{roadmap}}) accepts an arbitrary octet-string and maps
+it to a pseudorandom point on the curve.
+Note, however, that directly evaluating the mappings of {{mappings}} produces
+an output that is distinguishable from random.
 
-{{domain-separation}} describes considerations related to domain separation
-for random oracle encodings.
+{{domain-separation}} describes considerations related to domain separation.
 
-{{hashtofield}} describes considerations for uniformly hashing to field
-elements.
-When built on an expand\_message variant described in that section, and
-when following the security guidelines of that expand\_message variant,
-hash\_to\_field is indifferentiable from a random oracle;
-see {{security-considerations-hash-to-field}} and {{security-considerations-expand-md}}.
+{{hashtofield}} describes considerations for uniformly hashing to field elements;
+see {{security-considerations-hash-to-field}} and {{security-considerations-expand-md}}
+for further discussion.
 
 When the hash\_to\_curve function ({{roadmap}}) is instantiated with a
 hash\_to\_field function that is indifferentiable from a random oracle
@@ -2962,6 +2963,9 @@ is modeled as a random oracle.
 By composability of indifferentiability proofs, this also holds when
 expand\_message is proved indifferentiable from a random oracle relative
 to an underlying primitive that is modeled as a random oracle.
+When following the guidelines in {{hashtofield-expand}}, both variants
+of expand\_message defined in that section meet this requirement
+(see also {{security-considerations-expand-md}}).
 
 We very briefly sketch the indifferentiability argument for hash\_to\_field.
 Notice that each integer mod p that hash\_to\_field returns (i.e., each element
@@ -2971,6 +2975,17 @@ For each integer mod p that hash\_to\_field returns, the simulator samples
 one member of this equivalence class at random and outputs the octet-string
 returned by I2OSP.
 (Notice that this is essentially the inverse of the hash\_to\_field procedure.)
+
+Finally, we note that in the expand\_message variants defined in this document
+({{hashtofield-expand}}), the argument to every invocation of H (the underlying
+hash or extensible output function) is prepended with the domain separation
+tag DST.
+This ensures that invocations of H outside of hash\_to\_field can be separated
+from those inside of hash\_to\_field by prepending the outside invocations
+with a distinct domain separation tag.
+(Other expand\_message variants that follow the guidelines in
+{{hashtofield-expand-other}} should have similar properties; these SHOULD
+be analyzed on a case-by-case basis.)
 
 ## expand\_message\_md security {#security-considerations-expand-md}
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -166,6 +166,56 @@ informative:
         ins: P. Puniya
         name: Prashant Puniya
         org: New York University
+  MT07:
+    title: "Domain extension of public random functions: Beyond the birthday barrier"
+    seriesinfo:
+        "In": Advances in Cryptology - CRYPTO 2007
+        "pages": 187-204
+        DOI: 10.1007/978-3-540-74143-5_11
+    target: https://doi.org/10.1007/978-3-540-74143-5_11
+    date: 2007
+    author:
+      -
+        ins: U. Maurer
+        name: Ueli Maurer
+        org: ETH Zurich
+      -
+        ins: S. Tessaro
+        name: Stefano Tessaro
+        org: ETH Zurich
+  CN08:
+    title: "Improved indifferentiability security analysis for ChopMD hash function"
+    seriesinfo:
+        "In": FSE
+        "pages": 429-443
+        DOI: 10.1007/978-3-540-71039-4_27
+    target: https://doi.org/10.1007/978-3-540-71039-4_27
+    date: 2008
+    author:
+      -
+        ins: D. Chang
+        name: Donghoon Chang
+      -
+        ins: M. Nandi
+        name: Mridul Nandi
+  DFL12:
+    title: Generic indifferentiability proofs of hash designs
+    seriesinfo:
+        "In": CSF
+        "pages": 340-353
+        DOI: 10.1109/CSF.2012.13
+    target: https://doi.org/10.1109/CSF.2012.13
+    date: 2012
+    author:
+      -
+        ins: M. Daubignard
+        name: Marion Daubignard
+      -
+        ins: P-A. Fouque
+        name: Pierre-Alain Fouque
+      -
+        ins: Y. Lakhnech
+        name: Yassine Lakhnech
   BLAKE2X:
     title: BLAKE2X
     target: https://blake2.net/blake2x.pdf
@@ -286,7 +336,7 @@ informative:
     date: 2010
     author:
       -
-        ins: P. Fouque
+        ins: P-A. Fouque
         name: Pierre-Alain Fouque
         org: Ecole Normale Superieure and INRIA Rennes
       -
@@ -303,7 +353,7 @@ informative:
     date: 2012
     author:
       -
-        ins: P. Fouque
+        ins: P-A. Fouque
         name: Pierre-Alain Fouque
         org: Ecole Normale Superieure and INRIA Rennes
       -
@@ -320,7 +370,7 @@ informative:
     date: 2013
     author:
       -
-        ins: P. Fouque
+        ins: P-A. Fouque
         name: Pierre-Alain Fouque
         org: Ecole Normale Superieure and INRIA Rennes
       -
@@ -1513,19 +1563,19 @@ an implementation non-constant-time.
 ## Security considerations {#hashtofield-sec}
 
 The hash\_to\_field function is designed to be indifferentiable from a
-random oracle {{MRH04}}.
-Ensuring indifferentiability requires care, even when expand\_message is
-modeled as a random oracle (see {{hashtofield-expand}}, below).
-To see why, consider a prime p that is close to 3/4 * 2^256.
+random oracle {{MRH04}} when expand\_message ({{hashtofield-expand}})
+is modeled as a random oracle (see {{security-considerations-hash-to-field}}).
+Ensuring indifferentiability requires care; to see why, consider a prime
+p that is close to 3/4 * 2^256.
 Reducing a random 256-bit integer modulo this p yields a value that is in
 the range \[0, p / 3\] with probability roughly 1/2, meaning that this value
-is far from uniform in \[0, p - 1\].
+is statistically far from uniform in \[0, p - 1\].
 
 To control bias, hash\_to\_field instead uses pseudorandom integers whose
 length is at least ceil(log2(p)) + k bits.
 Reducing such integers mod p gives bias at most 2^-k for any p; this bias
 is appropriate for a cryptosystem with k-bit security.
-To obtain such an integer, hash\_to\_field uses expand\_message to obtain
+To obtain such integers, hash\_to\_field uses expand\_message to obtain
 L pseudorandom octets, where L = ceil((ceil(log2(p)) + k) / 8); this
 octet-string is then interpreted as an integer via OS2IP {{RFC8017}}.
 For example, for p a 255-bit prime and k = 128-bit security,
@@ -1568,8 +1618,8 @@ Notation:
   (b - a) octets starting at the a'th octet of str.
 
 Steps:
-1. pro_length = count * m * L
-2. pseudo_random_octets = expand_message(msg, DST, prb_length)
+1. len_in_octets = count * m * L
+2. pseudo_random_octets = expand_message(msg, DST, len_in_octets)
 3. for i in (0, ..., count - 1):
 4.   for j in (0, ..., m - 1):
 5.     elm_offset = L * (j + i * m)
@@ -1608,11 +1658,12 @@ a cryptographic hash function H that outputs b bits.
 For security, H must meet the following requirements:
 
 - The number of bits output by H MUST be b >= 2 * k, for k the target
-security level in bits. This ensures collision resistance to k bits.
+security level in bits. This ensures k-bit collision resistance.
 
 - H MAY be a Merkle-Damgaard hash function like SHA-2.
 In this case, security holds when the underlying compression function is
 modeled as a random oracle {{CDMP05}}.
+(See {{security-considerations-expand-md}} for discussion.)
 
 - H MAY be a sponge-based hash function like SHA-3 or BLAKE2.
 In this case, security holds when the inner function is modeled as a
@@ -2786,7 +2837,7 @@ Each encoding function accepts arbitrary input and maps it to a pseudorandom
 point on the curve.
 Directly evaluating the mappings of {{mappings}} produces an output that is
 distinguishable from random.
-{{roadmap}} shows how to use these mappings to construct a function that is
+{{roadmap}} shows how to use these mappings to construct hash\_to\_curve, which is
 indifferentiable from a random oracle.
 
 {{domain-separation}} describes considerations related to domain separation
@@ -2796,7 +2847,8 @@ for random oracle encodings.
 elements.
 When built on an expand\_message variant described in that section, and
 when following the security guidelines of that expand\_message variant,
-hash\_to\_field is indifferentiable from a random oracle.
+hash\_to\_field is indifferentiable from a random oracle;
+see {{security-considerations-hash-to-field}} and {{security-considerations-expand-md}}.
 
 When the hash\_to\_curve function ({{roadmap}}) is instantiated with a
 hash\_to\_field function that is indifferentiable from a random oracle
@@ -2818,6 +2870,57 @@ derivation function (e.g., PBKDF2 {{!RFC2898}} or scrypt {{!RFC7914}}) on the pa
 then hash the output of that function to the target elliptic curve.
 For collision resistance, the hash underlying the key derivation function
 should be chosen according to the guidelines listed in {{hashtofield-expand}}.
+
+## hash\_to\_field security {#security-considerations-hash-to-field}
+
+The hash\_to\_field function defined in {{hashtofield}} is indifferentiable
+from a random oracle {{MRH04}} when expand\_message ({{hashtofield-expand}})
+is modeled as a random oracle.
+By composability of indifferentiability proofs, this also holds when
+expand\_message is proved indifferentiable from a random oracle relative
+to an underlying primitive that is modeled as a random oracle.
+
+We very briefly sketch the indifferentiability argument for hash\_to\_field.
+Notice that each integer mod p that hash\_to\_field returns (i.e., each element
+of the vector representation of F) is a member of an equivalence class of roughly
+2^k integers of length log2(p) + k bits, all of which are equal modulo p.
+For each integer mod p that hash\_to\_field returns, the simulator samples
+one member of this equivalence class at random and outputs the octet-string
+returned by I2OSP.
+(Notice that this is essentially the inverse of the hash\_to\_field procedure.)
+
+## expand\_message\_md security {#security-considerations-expand-md}
+
+The expand\_message\_md function defined in {{hashtofield-expand-md}} is indifferentiable
+from a random oracle {{MRH04}} when any of the following hold:
+
+1. H is indifferentiable from a random oracle,
+2. H is a sponge-based hash function whose inner function
+   is modeled as a random transformation or random permutation {{BDPV08}}, or
+3. H is a Merkle-Damgaard hash function and the compression function is
+   modeled as a random oracle {{CDMP05}}.
+
+The first and second cases are true by the composability of indifferentiability
+proofs.
+For the third case, we now briefly sketch an indifferentiability argument.
+Here, H is a Merkle-Damgaard function; we model H's underlying compression
+function as a random oracle.
+
+First, we argue that each of the b_i values, i >= 1, is generated by a hash
+function that is indifferentiable from a random oracle.
+This follows from Theorem 3.4 of {{CDMP05}} and the fact that each call to H
+that generates one of these b_i values has a unique prefix, DST || I2OSP(i, 1).
+
+Next, we argue that b_0_chopped is generated by a hash function that is
+indifferentiable from a random oracle.
+This follows from Theorem 3.3 of {{CDMP05}}; {{MT07}}, {{CN08}}, and {{DFL12}}
+improve the analysis, giving tighter security bounds.
+
+Finally, since b_0_chopped and all b_i, i >= 1, are the outputs of hash
+functions indifferentiable from random oracles, their concatenation
+is also indifferentiable from a random oracle by the composability of
+indifferentiability proofs, as is a len_in_octets prefix of this concatenation.
+(See also {{CDMP05}}, Section 5.)
 
 # Acknowledgements
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1254,8 +1254,8 @@ Input: alpha, an arbitrary-length bit string.
 Output: P, a point in G.
 
 Steps:
-1. u = hash_to_field(alpha, 2)
-2. Q = map_to_curve(u)
+1. u = hash_to_field(alpha, 1)
+2. Q = map_to_curve(u[0])
 3. P = clear_cofactor(Q)
 4. return P
 ~~~
@@ -1272,13 +1272,12 @@ Input: alpha, an arbitrary-length bit string.
 Output: P, a point in G.
 
 Steps:
-1. u0 = hash_to_field(alpha, 0)
-2. u1 = hash_to_field(alpha, 1)
-3. Q0 = map_to_curve(u0)
-4. Q1 = map_to_curve(u1)
-5. R = Q0 + Q1              # Point addition
-6. P = clear_cofactor(R)
-7. return P
+1. u = hash_to_field(alpha, 2)
+2. Q0 = map_to_curve(u[0])
+3. Q1 = map_to_curve(u[1])
+4. R = Q0 + Q1              # Point addition
+5. P = clear_cofactor(R)
+6. return P
 ~~~
 
 Instances of these functions are given in {{suites}}, which defines a list of

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1673,11 +1673,8 @@ random transformation or as a random permutation {{BDPV08}}.
 from a random oracle {{MRH04}} under a reasonable cryptographic assumption.
 
 SHA-2 {{FIPS180-4}} and SHA-3 {{FIPS202}} are typical and RECOMMENDED choices.
-As an example, for 128-bit security, b >= 256 bits and either SHA256 or
+As an example, for 128-bit security, b >= 256 bits and either SHA-256 or
 SHA3-256 would be an appropriate choice.
-
-When using expand\_message\_md in a suite, the EXP\_TAG is "XMD".
-See {{suiteIDformat}} for details.
 
 The following procedure implements expand\_message\_md.
 
@@ -1728,9 +1725,6 @@ under a reasonable cryptographic assumption.
 The SHAKE {{FIPS202}} XOF family is a typical and RECOMMENDED choice.
 As an example, for 128-bit security, SHAKE-128 would be an appropriate choice.
 
-When using expand\_message\_md in a suite, the EXP\_TAG is "XOF".
-See {{suiteIDformat}} for details.
-
 The following procedure implements expand\_message\_md.
 
 ~~~
@@ -1778,7 +1772,7 @@ primitive, whereas a Mersenne twister pseudorandom number generator is not.
 
 In addition, an expand\_message variant MUST specify a unique EXP\_TAG
 that identifies that variant in a Suite ID.
-{{suiteIDformat}} gives details.
+See {{suiteIDformat}} for more information.
 
 # Deterministic Mappings {#mappings}
 
@@ -2491,21 +2485,23 @@ The RECOMMENDED way to define a new hash-to-curve suite is:
 
 1. E, F, p, and m are determined by the elliptic curve and its base field.
 
-2. Choose a sgn0 variant following the guidelines in {{sgn0-variants}}.
+2. Choose either hash\_to\_curve or encode\_to\_curve ({{roadmap}}).
 
-3. Compute L as described in {{hashtofield-sec}}.
+3. Choose a sgn0 variant following the guidelines in {{sgn0-variants}}.
 
-4. Choose an expand\_message variant from {{hashtofield-expand}} plus any
+4. Compute L as described in {{hashtofield-sec}}.
+
+5. Choose an expand\_message variant from {{hashtofield-expand}} plus any
    underlying cryptographic primitives (e.g., a hash function H).
 
-5. Choose a mapping following the guidelines in {{choosing-mapping}},
+6. Choose a mapping following the guidelines in {{choosing-mapping}},
    and select any required parameters for that mapping.
 
-6. Choose h\_eff to be either the cofactor of E or, if a fast cofactor
+7. Choose h\_eff to be either the cofactor of E or, if a fast cofactor
    clearing method is to be used, a value appropriate to that method
    as discussed in {{cofactor-clearing}}.
 
-7. Construct a Suite ID following the guidelines in {{suiteIDformat}}.
+8. Construct a Suite ID following the guidelines in {{suiteIDformat}}.
 
 When hashing to an elliptic curve not listed in this section, corresponding
 hash-to-curve suites SHOULD be specified as described in this section.
@@ -2533,9 +2529,14 @@ Fields MUST be chosen as follows:
 
         EXP_TAG || ":" || HASH_NAME
 
-  Here, HASH\_NAME is a human-readable name for the underlying hash primitive.
-  Hyphens are not allowed; any hyphens in the commonly-used name for the hash
-  function SHOULD be replaced with "." (ASCII 0x2e).
+  EXP\_TAG indicates the expand\_message variant:
+
+    - "XMD" for expand\_message\_md ({{hashtofield-expand-md}}).
+    - "XOF" for expand\_message\_xof ({{hashtofield-expand-xof}}).
+
+  HASH\_NAME is a human-readable name for the underlying hash primitive.
+  As stated above, hyphens are not allowed. Any hyphens in the commonly-used
+  name for the hash function SHOULD be replaced with "." (ASCII 0x2e).
 
   As examples:
 
@@ -2546,7 +2547,11 @@ Fields MUST be chosen as follows:
        HASH\_ID is "XMD:SHA3.256".
 
 - MAP\_ID: a human-readable representation of the map\_to\_curve function
-  ({{mappings}}).
+  as defined in {{mappings}}. These are defined as follows:
+
+    - "SVDW" for or Shallue and van de Woestijne ({{svdw}}).
+    - "SSWU" for Simplified SWU ({{simple-swu}}, {{simple-swu-AB0}}).
+    - "ELL2" for Elligator 2 ({{elligator2}}, {{ell2edwards}}).
 
 - ENC\_VAR: a string indicating the encoding type and other information.
   The first two characters of this string indicate whether the suite
@@ -2569,13 +2574,13 @@ Fields MUST be chosen as follows:
 
 This section defines ciphersuites for the NIST P-256 elliptic curve {{FIPS186-4}}.
 
-The suites P256-SHA256-SSWU-RO- and P256-SHA256-SSWU-NU-
+The suites P256-XMD:SHA.256-SSWU-RO- and P256-XMD:SHA.256-SSWU-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Simplified SWU method, {{simple-swu}}
 - Z: -10
 
-The suites P256-SHA256-SVDW-RO- and P256-SHA256-SVDW-NU-
+The suites P256-XMD:SHA.256-SVDW-RO- and P256-XMD:SHA.256-SVDW-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Shallue-van de Woestijne method, {{svdw}}
@@ -2589,6 +2594,7 @@ The common parameters for the above suites are:
 - p: 2^256 - 2^224 + 2^192 + 2^96 - 1
 - m: 1
 - sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-256
 - L: 48
 - h\_eff: 1
@@ -2600,13 +2606,13 @@ to P-256 is given in {{sswu-map-to-3mod4}}.
 
 This section defines ciphersuites for the NIST P-384 elliptic curve {{FIPS186-4}}.
 
-The suites P384-SHA512-SSWU-RO- and P384-SHA512-SSWU-NU-
+The suites P384-XMD:SHA.512-SSWU-RO- and P384-XMD:SHA.512-SSWU-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Simplified SWU method, {{simple-swu}}
 - Z: -12
 
-The suites P384-SHA512-SVDW-RO- and P384-SHA512-SVDW-NU-
+The suites P384-XMD:SHA.512-SVDW-RO- and P384-XMD:SHA.512-SVDW-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Shallue-van de Woestijne method, {{svdw}}
@@ -2620,6 +2626,7 @@ The common parameters for the above suites are:
 - p: 2^384 - 2^128 - 2^96 + 2^32 - 1
 - m: 1
 - sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-512
 - L: 72
 - h\_eff: 1
@@ -2631,13 +2638,13 @@ to P-384 is given in {{sswu-map-to-3mod4}}.
 
 This section defines ciphersuites for the NIST P-521 elliptic curve {{FIPS186-4}}.
 
-The suites P521-SHA512-SSWU-RO- and P521-SHA512-SSWU-NU-
+The suites P521-XMD:SHA.512-SSWU-RO- and P521-XMD:SHA.512-SSWU-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Simplified SWU method, {{simple-swu}}
 - Z: -4
 
-The suites P521-SHA512-SVDW-RO- and P521-SHA512-SVDW-NU-
+The suites P521-XMD:SHA.512-SVDW-RO- and P521-XMD:SHA.512-SVDW-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Shallue-van de Woestijne method, {{svdw}}
@@ -2651,6 +2658,7 @@ The common parameters for the above suites are:
 - p: 2^521 - 1
 - m: 1
 - sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-512
 - L: 96
 - h\_eff: 1
@@ -2662,7 +2670,7 @@ to P-521 is given in {{sswu-map-to-3mod4}}.
 
 This section defines ciphersuites for curve25519 and edwards25519 {{RFC7748}}.
 
-The suites curve25519-SHA256-ELL2-RO- and curve25519-SHA256-ELL2-NU-
+The suites curve25519-XMD:SHA.256-ELL2-RO- and curve25519-XMD:SHA.256-ELL2-NU-
 share the following parameters, in addition to the common parameters below.
 
 - E: K * t^2 = s^3 + J * s^2 + s, where
@@ -2670,7 +2678,7 @@ share the following parameters, in addition to the common parameters below.
   - K = 1
 - f: Elligator 2 method, {{elligator2}}
 
-The suites edwards25519-SHA256-EDELL2-RO- and edwards25519-SHA256-EDELL2-NU-
+The suites edwards25519-XMD:SHA.256-ELL2-RO- and edwards25519-XMD:SHA.256-ELL2-NU-
 share the following parameters, in addition to the common parameters below.
 
 - E: a * v^2 + w^2 = 1 + d * v^2 * w^2, where
@@ -2685,13 +2693,14 @@ The common parameters for all of the above suites are:
 - p: 2^255 - 19
 - m: 1
 - sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-256
 - L: 48
 - Z: 2
 - h\_eff: 8
 
-The suites curve25519-SHA512-ELL2-RO-, curve25519-SHA512-ELL2-NU-,
-edwards25519-SHA512-EDELL2-RO-, and edwards25519-SHA512-EDELL2-NU-
+The suites curve25519-XMD:SHA.512-ELL2-RO-, curve25519-XMD:SHA.512-ELL2-NU-,
+edwards25519-XMD:SHA.512-ELL2-RO-, and edwards25519-XMD:SHA.512-ELL2-NU-
 are identical to the correspondingly named suites defined above,
 except that H is SHA-512.
 
@@ -2702,7 +2711,7 @@ Optimized example implementations of the above mappings are given in
 
 This section defines ciphersuites for curve448 and edwards448 {{RFC7748}}.
 
-The suites curve448-SHA512-ELL2-RO- and curve448-SHA512-ELL2-NU-
+The suites curve448-XMD:SHA.512-ELL2-RO- and curve448-XMD:SHA.512-ELL2-NU-
 share the following parameters, in addition to the common parameters below.
 
 - E: K * t^2 = s^3 + J * s^2 + s, where
@@ -2710,7 +2719,7 @@ share the following parameters, in addition to the common parameters below.
   - K = 1
 - f: Elligator 2 method, {{elligator2}}
 
-The suites edwards448-SHA512-EDELL2-RO- and edwards448-SHA512-EDELL2-NU-
+The suites edwards448-XMD:SHA.512-ELL2-RO- and edwards448-XMD:SHA.512-ELL2-NU-
 share the following parameters, in addition to the common parameters below.
 
 - E: a * v^2 + w^2 = 1 + d * v^2 * w^2, where
@@ -2725,6 +2734,7 @@ The common parameters for all of the above suites are:
 - p: 2^448 - 2^224 - 1
 - m: 1
 - sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-512
 - L: 84
 - Z: -1
@@ -2737,7 +2747,7 @@ Optimized example implementations of the above mappings are given in
 
 This section defines ciphersuites for the secp256k1 elliptic curve {{SEC2}}.
 
-The suites secp256k1-SHA256-SSWU-RO- and secp256k1-SHA256-SSWU-NU-
+The suites secp256k1-XMD:SHA.256-SSWU-RO- and secp256k1-XMD:SHA.256-SSWU-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Simplified SWU for AB == 0, {{simple-swu-AB0}}
@@ -2747,7 +2757,7 @@ share the following parameters, in addition to the common parameters below.
   - B': 1771
 - iso\_map: the 3-isogeny map from E' to E given in {{appx-iso-secp256k1}}
 
-The suites secp256k1-SHA256-SVDW-RO- and secp256k1-SHA256-SVDW-NU-
+The suites secp256k1-XMD:SHA.256-SVDW-RO- and secp256k1-XMD:SHA.256-SVDW-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Shallue-van de Woestijne method, {{svdw}}
@@ -2759,6 +2769,7 @@ The common parameters for all of the above suites are:
 - p: 2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1
 - m: 1
 - sgn0: sgn0\_le ({{sgn0-le}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-256
 - L: 48
 - h\_eff: 1
@@ -2773,7 +2784,7 @@ the BLS12-381 elliptic curve {{BLS12-381}}.
 
 ### BLS12-381 G1 {#suites-bls12381-g1}
 
-The suites BLS12381G1-SHA256-SSWU-RO- and BLS12381G1-SHA256-SSWU-NU-
+The suites BLS12381G1-XMD:SHA.256-SSWU-RO- and BLS12381G1-XMD:SHA.256-SSWU-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Simplified SWU for AB == 0, {{simple-swu-AB0}}
@@ -2783,7 +2794,7 @@ share the following parameters, in addition to the common parameters below.
   - B' = 0x12e2908d11688030018b12e8753eee3b2016c1f0f24f4070a0b9c14fcef35ef55a23215a316ceaa5d1cc48e98e172be0
 - iso\_map: the 11-isogeny map from E' to E given in {{appx-iso-bls12381-g1}}
 
-The suites BLS12381G1-SHA256-SVDW-RO- and BLS12381G1-SHA256-SVDW-NU-
+The suites BLS12381G1-XMD:SHA.256-SVDW-RO- and BLS12381G1-XMD:SHA.256-SVDW-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Shallue-van de Woestijne method, {{svdw}}
@@ -2795,6 +2806,7 @@ The common parameters for the above suites are:
 - p: 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
 - m: 1
 - sgn0: sgn0\_be ({{sgn0-be}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-256
 - L: 64
 - h\_eff: 0xd201000000010001
@@ -2813,7 +2825,7 @@ Group G2 of BLS12-381 is defined over a field F = GF(p^m) defined as:
 - m: 2
 - (1, I) is the basis for F, where I^2 + 1 == 0 in F
 
-The suites BLS12381G2-SHA256-SSWU-RO- and BLS12381G2-SHA256-SSWU-NU-
+The suites BLS12381G2-XMD:SHA.256-SSWU-RO- and BLS12381G2-XMD:SHA.256-SSWU-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Simplified SWU for AB == 0, {{simple-swu-AB0}}
@@ -2823,7 +2835,7 @@ share the following parameters, in addition to the common parameters below.
   - B' = 1012 * (1 + I)
 - iso\_map: the isogeny map from E' to E given in {{appx-iso-bls12381-g2}}
 
-The suites BLS12381G2-SHA256-SVDW-RO- and BLS12381G2-SHA256-SVDW-NU-
+The suites BLS12381G2-XMD:SHA.256-SVDW-RO- and BLS12381G2-XMD:SHA.256-SVDW-NU-
 share the following parameters, in addition to the common parameters below.
 
 - f: Shallue-van de Woestijne method, {{svdw}}
@@ -2834,6 +2846,7 @@ The common parameters for the above suites are:
 - E: y^2 = x^3 + 4 * (1 + I)
 - p, m, F: defined above
 - sgn0: sgn0\_be ({{sgn0-be}})
+- expand\_message: expand\_message\_md ({{hashtofield-expand-md}})
 - H: SHA-256
 - L: 64
 - h\_eff: 0xbc69f08f2ee75b3584c6a0ea91b352888e2a8e9145ad7689986ff031508ffe1329c2f178731db956d82bf015d1212b02ec0ec69d7477c1ae954cbc06689f6a359894c0adebbf6b4e8020005aaa95551

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1650,7 +1650,7 @@ Notation:
   (b - a) octets starting at the a'th octet of str.
 
 Steps:
-1. ell = ceil((len_in_octets - k_in_octets) / b_in_octets)
+1. ell = ceil((len_in_octets + k_in_octets) / b_in_octets)
 2. ABORT if ell > 255
 3. b_0 = H(DST || I2OSP(0, 1) || I2OSP(ell, 1) || msg)
 4. for i in (1, ..., ell - 1):

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1067,7 +1067,7 @@ protocol.
 This document aims to bridge this gap by providing a thorough set of
 recommended algorithms for a range of curve types.
 Each algorithm conforms to a common interface: it takes as input an arbitrary-length
-octet-string and produces as output a point on an elliptic curve.
+byte string and produces as output a point on an elliptic curve.
 We provide implementation details for each algorithm, describe
 the security rationale behind each recommendation, and give guidance for
 elliptic curves that are not explicitly covered.
@@ -1152,7 +1152,7 @@ Summary of quantities:
 | F,q,p | Finite field F of characteristic p and #F = q = p^m. | For prime fields, q = p; otherwise, q = p^m and m>1. |
 | E | Elliptic curve. | E is specified by an equation and a field F. |
 | n | Number of points on the elliptic curve E. | n = h * r, for h and r defined below. |
-| G | A subgroup of the elliptic curve. | Destination group to which octet-strings are encoded. |
+| G | A subgroup of the elliptic curve. | Destination group to which byte strings are encoded. |
 | r | Order of G. | This number MUST be prime.  |
 | h | Cofactor, h >= 1. | An integer satisfying n = h * r.  |
 
@@ -1185,23 +1185,23 @@ document does not discuss inversion algorithms.
 
 Encodings are closely related to mappings.
 Like a mapping, an encoding is a function that outputs a point on an elliptic curve.
-In contrast to a mapping, however, the input to an encoding is an arbitrary bit string.
+In contrast to a mapping, however, the input to an encoding is an arbitrary string.
 Encodings can be deterministic or probabilistic.
 Deterministic encodings are preferred for security, because probabilistic
-ones can leak information through side channels.
+ones are more likely to leak information through side channels.
 
 This document constructs deterministic encodings by composing a hash function H
 with a deterministic mapping.
-In particular, H takes as input an arbitrary bit string and outputs an element of F.
+In particular, H takes as input an arbitrary string and outputs an element of F.
 The deterministic mapping takes that element as input and outputs a point on an
 elliptic curve E defined over F.
-Since the hash function H takes arbitrary bit strings as inputs, it cannot be
+Since the hash function H takes arbitrary strings as inputs, it cannot be
 injective: the set of inputs is larger than the set of outputs, so there must
 be distinct inputs that give the same output (i.e., there must be collisions).
 Thus, any encoding built from H is also not injective.
 
 Like mappings, encodings may be invertible, meaning that there is an efficient
-algorithm that, for any point P output by the encoding, outputs a bit string s
+algorithm that, for any point P output by the encoding, outputs a string s
 such that applying the encoding to s outputs P.
 The hash function used by all encodings specified in this document ({{hashtofield}})
 is not invertible; thus, the encodings are also not invertible.
@@ -1242,7 +1242,7 @@ For example, {{SEC1}} and {{p1363a}} give standard methods for serialization and
 
 Deserialization is different from encoding in that only certain strings
 (namely, those output by the serialization procedure) can be deserialized.
-In contrast, this document is concerned with encodings from arbitrary bit strings
+In contrast, this document is concerned with encodings from arbitrary strings
 to elliptic curve points.
 This document does not cover serialization or deserialization.
 
@@ -1274,11 +1274,11 @@ Thus, it is safe to treat RO1 and RO2 as independent oracles.
 
 # Roadmap {#roadmap}
 
-This section presents a general framework for encoding bit strings to points
+This section presents a general framework for encoding byte strings to points
 on an elliptic curve. To construct these encodings, we rely on three basic
 functions:
 
--   The function hash\_to\_field, {0, 1}^\* x {0, 1, 2} -> F, hashes arbitrary-length bit strings
+-   The function hash\_to\_field, {0, 1}^\* x {0, 1, 2} -> F, hashes arbitrary-length byte strings
     to elements of a finite field; its implementation is defined in
     {{hashtofield}}.
 
@@ -1294,13 +1294,13 @@ We describe two high-level encoding functions ({{term-encoding}}).
 Although these functions have the same interface, the
 distributions of their outputs are different.
 
--   Nonuniform encoding (encode\_to\_curve). This function encodes bit strings to points in G.
+-   Nonuniform encoding (encode\_to\_curve). This function encodes byte strings to points in G.
     The distribution of the output is not uniformly random in G.
 
 ~~~
 encode_to_curve(alpha)
 
-Input: alpha, an arbitrary-length bit string.
+Input: alpha, an arbitrary-length byte string.
 Output: P, a point in G.
 
 Steps:
@@ -1310,7 +1310,7 @@ Steps:
 4. return P
 ~~~
 
--   Random oracle encoding (hash\_to\_curve). This function encodes bit strings to points in G.
+-   Random oracle encoding (hash\_to\_curve). This function encodes byte strings to points in G.
     This function is suitable for applications requiring a random oracle returning points in G,
     provided that map\_to\_curve is "well distributed" ({{FFSTV13}}, Def. 1).
     All of the map\_to\_curve functions defined in {{mappings}} meet this requirement.
@@ -1318,7 +1318,7 @@ Steps:
 ~~~
 hash_to_curve(alpha)
 
-Input: alpha, an arbitrary-length bit string.
+Input: alpha, an arbitrary-length byte string.
 Output: P, a point in G.
 
 Steps:
@@ -1349,7 +1349,7 @@ curve and in the case of multiple hashes to different curves.
 domain separation to guarantee independent outputs.)
 
 Domain separation is enforced with a domain separation tag (DST),
-which is an octet-string.
+which is a byte string.
 Care is required when selecting and using a domain separation tag.
 The following requirements apply:
 
@@ -1436,10 +1436,10 @@ is_square(x) := { True,  if x^((q - 1) / 2) is 0 or 1 in F;
     To implement inv0 in constant time, compute inv0(x) := x^(q - 2).
     Notice on input 0, the output is 0 as required.
 
--   I2OSP and OS2IP: These functions are used to convert an octet-string to
+-   I2OSP and OS2IP: These functions are used to convert a byte string to
     and from a non-negative integer as described in {{RFC8017}}.
 
--   a \|\| b: denotes the concatenation of bit strings a and b.
+-   a \|\| b: denotes the concatenation of strings a and b.
 
 ## sgn0 variants {#sgn0-variants}
 
@@ -1540,11 +1540,11 @@ Steps:
 
 # Hashing to a Finite Field {#hashtofield}
 
-The hash\_to\_field function hashes an octet-string msg of any length into
+The hash\_to\_field function hashes a byte string msg of any length into
 one or more elements of a field F.
-This function works in two steps: it first expands the input octet-string
-into a pseudorandom octet-string, and then interprets this pseudorandom
-octet-string as one or more elements of F.
+This function works in two steps: it first expands the input byte string
+into a pseudorandom byte string, and then interprets this pseudorandom
+byte string as one or more elements of F.
 
 For the first step, hash\_to\_field calls an auxiliary function
 expand\_message.
@@ -1576,10 +1576,10 @@ length is at least ceil(log2(p)) + k bits.
 Reducing such integers mod p gives bias at most 2^-k for any p; this bias
 is appropriate for a cryptosystem with k-bit security.
 To obtain such integers, hash\_to\_field uses expand\_message to obtain
-L pseudorandom octets, where L = ceil((ceil(log2(p)) + k) / 8); this
-octet-string is then interpreted as an integer via OS2IP {{RFC8017}}.
+L pseudorandom bytes, where L = ceil((ceil(log2(p)) + k) / 8); this
+byte string is then interpreted as an integer via OS2IP {{RFC8017}}.
 For example, for p a 255-bit prime and k = 128-bit security,
-L = ceil((255 + 128) / 8) = 48 octets.
+L = ceil((255 + 128) / 8) = 48 bytes.
 
 ## hash\_to\_field implementation {#hashtofield-impl}
 
@@ -1602,28 +1602,28 @@ Parameters:
 - m, the extension degree of F, m >= 1 (see immediately above).
 - L = ceil((ceil(log2(p)) + k) / 8), where k is the security
   parameter of the cryptosystem (e.g., k = 128).
-- expand_message, a function that expands an octet-string and
-  domain separation tag into a pseudorandom octet-string
+- expand_message, a function that expands a byte string and
+  domain separation tag into a pseudorandom byte string
   (see discussion above).
 
 Inputs:
-- msg is an octet-string containing the message to hash.
+- msg is a byte string containing the message to hash.
 - count is the number of elements of F to output.
 
 Outputs:
 - (u_1, ..., u_(count)), a list of field elements.
 
 Notation:
-- For an octet-string str, let str[a : b] represent the
-  (b - a) octets starting at the a'th octet of str.
+- For a byte string str, let str[a : b] represent the
+  (b - a) bytes starting at the a'th byte of str.
 
 Steps:
-1. len_in_octets = count * m * L
-2. pseudo_random_octets = expand_message(msg, DST, len_in_octets)
+1. len_in_bytes = count * m * L
+2. pseudo_random_bytes = expand_message(msg, DST, len_in_bytes)
 3. for i in (0, ..., count - 1):
 4.   for j in (0, ..., m - 1):
 5.     elm_offset = L * (j + i * m)
-6.     tv = pseudo_random_octets[elm_offset : (elm_offset + L)]
+6.     tv = pseudo_random_bytes[elm_offset : (elm_offset + L)]
 7.     e_j = OS2IP(tv) mod p
 8.   u_i = (e_0, ..., e_(m - 1))
 9. return (u_0, ..., u_(count - 1))
@@ -1631,12 +1631,12 @@ Steps:
 
 ## expand\_message {#hashtofield-expand}
 
-expand\_message is a function that generates a pseudorandom octet-string.
+expand\_message is a function that generates a pseudorandom byte string.
 It takes three arguments:
 
-- msg, an octet-string containing the message to hash,
-- DST, an octet-string that acts as a domain separation tag, and
-- len\_in\_octets, the number of octets to be generated.
+- msg, a byte string containing the message to hash,
+- DST, a byte string that acts as a domain separation tag, and
+- len\_in\_bytes, the number of bytes to be generated.
 
 This document defines two variants of expand\_message:
 
@@ -1653,7 +1653,7 @@ variants are possible; {{hashtofield-expand-other}} discusses requirements.
 
 ### expand\_message\_md {#hashtofield-expand-md}
 
-The expand\_message\_md function produces a pseudorandom octet string using
+The expand\_message\_md function produces a pseudorandom byte string using
 a cryptographic hash function H that outputs b bits.
 For security, H must meet the following requirements:
 
@@ -1679,41 +1679,41 @@ SHA3-256 would be an appropriate choice.
 The following procedure implements expand\_message\_md.
 
 ~~~
-expand_message_md(msg, DST, len_in_octets)
+expand_message_md(msg, DST, len_in_bytes)
 
 Parameters:
 - H, a hash function (see requirements above).
-- b_in_octets, ceil(b / 8) for b the output size of H in bits.
-  For example, for b = 256, b_in_octets = 32.
-- k_in_octets, ceil(k / 8) for k the security parameter.
-  For example, for k = 128, k_in_octets = 16.
+- b_in_bytes, ceil(b / 8) for b the output size of H in bits.
+  For example, for b = 256, b_in_bytes = 32.
+- k_in_bytes, ceil(k / 8) for k the security parameter.
+  For example, for k = 128, k_in_bytes = 16.
 
 Input:
-- msg, an octet string.
-- DST, an octet string.
-- len_in_octets, the length of the requested output in octets.
+- msg, a byte string.
+- DST, a byte string.
+- len_in_bytes, the length of the requested output in bytes.
 
 Output:
-- pseudo_random_octets, an octet string
+- pseudo_random_bytes, a byte string
 
 Notation:
-- For an octet-string str, let str[a : b] represent the
-  (b - a) octets starting at the a'th octet of str.
+- For a byte string str, let str[a : b] represent the
+  (b - a) bytes starting at the a'th byte of str.
 
 Steps:
-1. ell = ceil((len_in_octets + k_in_octets) / b_in_octets)
+1. ell = ceil((len_in_bytes + k_in_bytes) / b_in_bytes)
 2. ABORT if ell > 256
-3. b_0 = H(DST || I2OSP(0, 1) || I2OSP(len_in_octets, 2) || msg)
+3. b_0 = H(DST || I2OSP(0, 1) || I2OSP(len_in_bytes, 2) || msg)
 4. for i in (1, ..., ell - 1):
 5.   b_i = H(DST || I2OSP(i, 1) || b_(i - 1))
-6. b_0_chopped = b_0[0 : (b_in_octets - k_in_octets)]
-7. pseudo_random_octets = b_0_chopped || b_1 || ... || b_(ell - 1)
-8. return pseudo_random_octets[0 : len_in_octets]
+6. b_0_chopped = b_0[0 : (b_in_bytes - k_in_bytes)]
+7. pseudo_random_bytes = b_0_chopped || b_1 || ... || b_(ell - 1)
+8. return pseudo_random_bytes[0 : len_in_bytes]
 ~~~
 
 ### expand\_message\_xof {#hashtofield-expand-xof}
 
-The expand\_message\_xof function produces a pseudorandom octet string
+The expand\_message\_xof function produces a pseudorandom byte string
 using an extensible-output function (XOF) H.
 For security, H must meet the following criteria:
 
@@ -1728,24 +1728,24 @@ As an example, for 128-bit security, SHAKE-128 would be an appropriate choice.
 The following procedure implements expand\_message\_md.
 
 ~~~
-expand_message_xof(msg, DST, len_in_octets)
+expand_message_xof(msg, DST, len_in_bytes)
 
 Parameters:
 - H, an extensible-output function.
-  H(m, d) hashes message m and returns d octets.
+  H(m, d) hashes message m and returns d bytes.
 
 Input:
-- msg, an octet string.
-- DST, an octet string.
-- len_in_octets, the length of the requested output in octets.
+- msg, a byte string.
+- DST, a byte string.
+- len_in_bytes, the length of the requested output in bytes.
 
 Output:
-- pseudo_random_octets, an octet string
+- pseudo_random_bytes, a byte string
 
 Steps:
-1. msg_prime = DST || I2OSP(len_in_octets, 2) || msg
-2. pseudo_random_octets = H(msg_prime, len_in_octets)
-3. return pseudo_random_octets
+1. msg_prime = DST || I2OSP(len_in_bytes, 2) || msg
+2. pseudo_random_bytes = H(msg_prime, len_in_bytes)
+3. return pseudo_random_bytes
 ~~~
 
 ### Defining other expand\_message variants {#hashtofield-expand-other}
@@ -2444,7 +2444,7 @@ generally give the same result as the fast method, and SHOULD NOT be used.
 
 This section lists recommended suites for hashing to standard elliptic curves.
 
-A suite fully specifies the procedure for hashing bit strings to
+A suite fully specifies the procedure for hashing byte strings to
 points on a specific elliptic curve group.
 Each suite comprises the following parameters:
 
@@ -2923,7 +2923,7 @@ Defending against such leakage is outside the scope of this document, because
 the nature of the leakage and the appropriate defense depends on the protocol
 from which a hash-to-curve function is invoked.
 
-Each encoding variant ({{roadmap}}) accepts an arbitrary octet-string and maps
+Each encoding variant ({{roadmap}}) accepts an arbitrary byte string and maps
 it to a pseudorandom point on the curve.
 Note, however, that directly evaluating the mappings of {{mappings}} produces
 an output that is distinguishable from random.
@@ -2972,7 +2972,7 @@ Notice that each integer mod p that hash\_to\_field returns (i.e., each element
 of the vector representation of F) is a member of an equivalence class of roughly
 2^k integers of length log2(p) + k bits, all of which are equal modulo p.
 For each integer mod p that hash\_to\_field returns, the simulator samples
-one member of this equivalence class at random and outputs the octet-string
+one member of this equivalence class at random and outputs the byte string
 returned by I2OSP.
 (Notice that this is essentially the inverse of the hash\_to\_field procedure.)
 
@@ -3017,7 +3017,7 @@ improve the analysis, giving tighter security bounds.
 Finally, since b_0_chopped and all b_i, i >= 1, are the outputs of hash
 functions indifferentiable from random oracles, their concatenation
 is also indifferentiable from a random oracle by the composability of
-indifferentiability proofs, as is a len_in_octets prefix of this concatenation.
+indifferentiability proofs, as is a len_in_bytes prefix of this concatenation.
 (See also {{CDMP05}}, Section 5.)
 
 # Acknowledgements

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2787,17 +2787,22 @@ Each encoding function accepts arbitrary input and maps it to a pseudorandom
 point on the curve.
 Directly evaluating the mappings of {{mappings}} produces an output that is
 distinguishable from random.
-{{roadmap}} shows how to use these mappings to construct a function approximating a
-random oracle.
+{{roadmap}} shows how to use these mappings to construct a function that is
+indifferentiable from a random oracle.
 
 {{domain-separation}} describes considerations related to domain separation
 for random oracle encodings.
 
-{{hashtofield}} describes considerations for uniformly hashing to field elements.
+{{hashtofield}} describes considerations for uniformly hashing to field
+elements.
+When built on an expand\_message variant described in that section, and
+when following the security guidelines of that expand\_message variant,
+hash\_to\_field is indifferentiable from a random oracle.
 
-When the hash\_to\_curve function ({{roadmap}}) is instantiated
-with hash\_to\_field ({{hashtofield}}), the resulting function is
-indifferentiable from a random oracle ({{FFSTV13}}, {{LBB19}}, {{MRH04}}).
+When the hash\_to\_curve function ({{roadmap}}) is instantiated with a
+hash\_to\_field function that is indifferentiable from a random oracle
+({{hashtofield}}), the resulting function is indifferentiable from a random
+oracle ({{FFSTV13}}, {{LBB19}}, {{MRH04}}).
 In most cases such a function can be safely used in protocols whose security
 analysis assumes a random oracle that outputs points on an elliptic curve.
 As Ristenpart et al. discuss in {{RSS11}}, however, not all security proofs
@@ -2813,7 +2818,7 @@ To mitigate such attacks, it is recommended to first execute a more costly key
 derivation function (e.g., PBKDF2 {{!RFC2898}} or scrypt {{!RFC7914}}) on the password,
 then hash the output of that function to the target elliptic curve.
 For collision resistance, the hash underlying the key derivation function
-should be chosen according to the guidelines listed in {{hashtofield-sec}}.
+should be chosen according to the guidelines listed in {{hashtofield-expand}}.
 
 # Acknowledgements
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1542,8 +1542,8 @@ Steps:
 
 The hash\_to\_field function hashes a byte string msg of any length into
 one or more elements of a field F.
-This function works in two steps: it first expands the input byte string
-into a pseudorandom byte string, and then interprets this pseudorandom
+This function works in two steps: it first hashes the input byte string
+to produce a pseudorandom byte string, and then interprets this pseudorandom
 byte string as one or more elements of F.
 
 For the first step, hash\_to\_field calls an auxiliary function
@@ -1574,11 +1574,11 @@ is statistically far from uniform in \[0, p - 1\].
 To control bias, hash\_to\_field instead uses pseudorandom integers whose
 length is at least ceil(log2(p)) + k bits.
 Reducing such integers mod p gives bias at most 2^-k for any p; this bias
-is appropriate for a cryptosystem with k-bit security.
+is appropriate when targeting k-bit security.
 To obtain such integers, hash\_to\_field uses expand\_message to obtain
 L pseudorandom bytes, where L = ceil((ceil(log2(p)) + k) / 8); this
 byte string is then interpreted as an integer via OS2IP {{RFC8017}}.
-For example, for p a 255-bit prime and k = 128-bit security,
+For example, for a 255-bit prime p, and k = 128-bit security,
 L = ceil((255 + 128) / 8) = 48 bytes.
 
 ## hash\_to\_field implementation {#hashtofield-impl}
@@ -1611,11 +1611,11 @@ Inputs:
 - count is the number of elements of F to output.
 
 Outputs:
-- (u_1, ..., u_(count)), a list of field elements.
+- (u_0, ..., u_(count - 1)), a list of field elements.
 
 Notation:
 - For a byte string str, let str[a : b] represent the
-  (b - a) bytes starting at the a'th byte of str.
+  (b - a) bytes starting at str[a].
 
 Steps:
 1. len_in_bytes = count * m * L
@@ -1673,7 +1673,7 @@ random transformation or as a random permutation {{BDPV08}}.
 from a random oracle {{MRH04}} under a reasonable cryptographic assumption.
 
 SHA-2 {{FIPS180-4}} and SHA-3 {{FIPS202}} are typical and RECOMMENDED choices.
-As an example, for 128-bit security, b >= 256 bits and either SHA-256 or
+As an example, for the 128-bit security level, b >= 256 bits and either SHA-256 or
 SHA3-256 would be an appropriate choice.
 
 The following procedure implements expand\_message\_md.
@@ -1698,7 +1698,7 @@ Output:
 
 Notation:
 - For a byte string str, let str[a : b] represent the
-  (b - a) bytes starting at the a'th byte of str.
+  (b - a) bytes starting at str[a].
 
 Steps:
 1. ell = ceil((len_in_bytes + k_in_bytes) / b_in_bytes)
@@ -2715,8 +2715,8 @@ except for the following parameters:
 
 - f: Shallue-van de Woestijne method, {{svdw}}
 - Z: 1
-- E' is not defined for this suite
-- iso\_map is not defined for this suite
+- E' is not required for this suite
+- iso\_map is not required for this suite
 
 secp256k1-XMD:SHA.256-SSWU-NU- is identical to secp256k1-XMD:SHA.256-SSWU-RO-,
 except that the encoding type is encode\_to\_curve ({{roadmap}}).
@@ -2758,8 +2758,8 @@ except for the following parameters:
 
 - f: Shallue-van de Woestijne method, {{svdw}}
 - Z: -3
-- E' is not defined for this suite
-- iso\_map is not defined for this suite
+- E' is not required for this suite
+- iso\_map is not required for this suite
 
 BLS12381G1-XMD:SHA.256-SSWU-NU- is identical to BLS12381G1-XMD:SHA.256-SSWU-RO-,
 except that the encoding type is encode\_to\_curve ({{roadmap}}).
@@ -2803,8 +2803,8 @@ except for the following parameters:
 
 - f: Shallue-van de Woestijne method, {{svdw}}
 - Z: I
-- E' is not defined for this suite
-- iso\_map is not defined for this suite
+- E' is not required for this suite
+- iso\_map is not required for this suite
 
 BLS12381G2-XMD:SHA.256-SSWU-NU- is identical to BLS12381G2-XMD:SHA.256-SSWU-RO-,
 except that the encoding type is encode\_to\_curve ({{roadmap}}).

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2854,8 +2854,12 @@ The fields CURVE\_ID, HASH\_ID, MAP\_ID, and ENC\_VAR are
 ASCII-encoded strings of at most 64 characters each.
 Fields can contain only ASCII characters between 0x21 and 0x7E (inclusive)
 other than hyphen and underscore (i.e., 0x2d, and 0x5f).
+
 As indicated above, each field (including the last) is followed by a hyphen
-("-", ASCII 0x2d); this helps to ensure that Suite IDs are prefix free.
+("-", ASCII 0x2d).
+This helps to ensure that Suite IDs are prefix free.
+Suite IDs MUST include the final hyphen and MUST NOT include any characters
+after the final hyphen.
 
 Fields MUST be chosen as follows:
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2535,8 +2535,8 @@ Fields MUST be chosen as follows:
     - "XOF" for expand\_message\_xof ({{hashtofield-expand-xof}}).
 
   HASH\_NAME is a human-readable name for the underlying hash primitive.
-  As stated above, hyphens are not allowed. Any hyphens in the commonly-used
-  name for the hash function SHOULD be replaced with "." (ASCII 0x2e).
+  As stated above, hyphens are not allowed. Any hyphens in the name of the
+  hash function SHOULD be replaced with "." (ASCII 0x2e).
 
   As examples:
 

--- a/poc/sswu_opt.sage
+++ b/poc/sswu_opt.sage
@@ -3,7 +3,7 @@
 
 import sys
 try:
-    from sagelib.common import CMOV
+    from sagelib.common import CMOV, sgn0_be
     from sagelib.sswu_generic import GenericSSWU
     from sagelib.z_selection import find_z_sswu
 except ImportError:
@@ -122,6 +122,7 @@ p_bls12381 = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241
 Ap_bls12381g1 = 0x144698a3b8e9433d693a02c96d4982b0ea985383ee66a8d8e8981aefd881ac98936f8da0e0f97f5cf428082d584c1d
 Bp_bls12381g1 = 0x12e2908d11688030018b12e8753eee3b2016c1f0f24f4070a0b9c14fcef35ef55a23215a316ceaa5d1cc48e98e172be0
 test_bls12381g1 = OptimizedSSWU(p_bls12381, Ap_bls12381g1, Bp_bls12381g1)
+test_bls12381g1.ref_map.set_sgn0(sgn0_be)
 assert test_bls12381g1.Z == GF(p_bls12381)(11)
 
 def test_sswu():


### PR DESCRIPTION
This PR redefines hash_to_field in the way discussed in #202.

Now ready for review, I believe.

Todo:

- [x] rename to hash_to_field
- [x] write new definitions and security considerations
- [x] update Security Considerations section
- [x] update Roadmap section
- [x] update Suites section
- ~update implementations~  we can do this in a separate PR (or I'm happy to do it here... what do we think?)

@armfazh @chris-wood @JustinDrake I'd appreciate comments on the WIP version. I'm sure I've left typos, things aren't super clear yet, etc.!