### PR TITLE
remove explicit use of "Long" Weierstrass equations

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -3486,7 +3486,7 @@ Steps:
 20. tv4 = tv4 * tv2            # gx1 * gxd^3
 21.  y1 = tv4^c1               # (gx1 * gxd^3)^((p - 3) / 4)
 22.  y1 = y1 * tv2             # gx1 * gxd * (gx1 * gxd^3)^((p - 3) / 4)
-23. x2n = tv3 * x1n            # x2 = x2n / xd = -10 * u^2 * x1n / xd
+23. x2n = tv3 * x1n            # x2 = x2n / xd = Z * u^2 * x1n / xd
 24.  y2 = y1 * c2              # y2 = y1 * sqrt(-Z^3)
 25.  y2 = y2 * tv1
 26.  y2 = y2 * u

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -99,23 +99,6 @@ informative:
     author:
       -
         org: National Institute of Standards and Technology (NIST)
-  SP.800-185:
-    title: "SHA-3 Derived Functions: cSHAKE, KMAC, TupleHash and ParallelHash"
-    target: https://doi.org/10.6028/NIST.SP.800-185
-    date: Dec, 2016
-    author:
-      -
-        ins: J. Kelsey
-        name: John Kelsey
-        org: NIST Computer Security Division
-      -
-        ins: S. Chang
-        name: Shu-jen Chang
-        org: NIST Computer Security Division
-      -
-        ins: R. Perlner
-        name: Ray Perlner
-        org: NIST Computer Security Division
   BDPV08:
     title: On the Indifferentiability of the Sponge Construction
     seriesinfo:
@@ -972,31 +955,6 @@ informative:
         ins: K. Bhargavan
         name: Karthikeyan Bhargavan
         org: INRIA Paris
-  DRST12:
-    title: "To hash or not to hash again? (In)differentiability results for H^2 and HMAC"
-    seriesinfo:
-      "In": Advances in Cryptology - CRYPTO 2012
-      "pages": 348-366
-      DOI: 10.1007/978-3-642-32009-5_21
-    target: https://doi.org/10.1007/978-3-642-32009-5_21
-    date: Aug, 2012
-    author:
-      -
-        ins: Y. Dodis
-        name: Yevgeniy Dodis
-        org: New York University
-      -
-        ins: T. Ristenpart
-        name: Thomas Ristenpart
-        org: University of Wisconsin-Madison
-      -
-        ins: J. Steinberger
-        name: John Steinberger
-        org: Tsinghua University
-      -
-        ins: S. Tessaro
-        name: Stefano Tessaro
-        org: Massachusetts Institute of Technology
   RSS11:
     title: "Careful with Composition: Limitations of the Indifferentiability Framework"
     seriesinfo:
@@ -3144,7 +3102,7 @@ This document does not deal with this complementary problem.
 
 This section gives several useful rational maps.
 
-## Twisted Edwards Montgomery curves {#appx-rational-map-edw}
+## Twisted Edwards to Montgomery curves {#appx-rational-map-edw}
 
 This section gives a generic birational map between twisted Edwards
 and Montgomery curves.
@@ -3171,9 +3129,12 @@ To convert from twisted Edwards to Montgomery form, the mapping is
 - s = (1 + w) / (1 - w)
 - t = (1 + w) / (v * (1 - w))
 
-This mapping requires that a != d.
+This mapping is defined when a != d, which is guaranteed by the definition
+of twisted Edwards curves.
 The mapping is undefined when v == 0 or w == 1.
-In this case, return the identity point on the Montgomery curve.
+If (v, w) == (0, -1), return the point (s, t) = (0, 0).
+For all other undefined inputs, return the identity point on the Montgomery curve.
+(This follows from [BBJLP08], Section 3.)
 
 To convert from Montgomery to twisted Edwards form, the mapping is
 
@@ -3182,10 +3143,19 @@ To convert from Montgomery to twisted Edwards form, the mapping is
 - v = s / t
 - w = (s - 1) / (s + 1)
 
-This mapping requires that J != 2, J != -2, and K != 0.
+This mapping is defined when J != 2, J != -2, and K != 0; all Montgomery
+curves meet these criteria.
 The mapping is undefined when t == 0 or s == -1.
-In this case, return the point (v, w) = (0, 1), which is
-the identity point on all twisted Edwards curves.
+If (s, t) == (0, 0), return the point (v, w) = (0, -1).
+For all other undefined inputs, return the identity point on the twisted
+Edwards curve, namely, (v, w) = (0, 1).
+(This follows from [BBJLP08], Section 3.)
+
+(Note that {{rational-map}} gives a simpler rule for handling undefined
+inputs to this rational map: always return the identity point.
+The simpler rule gives the same result when used as part of an encoding
+function ({{roadmap}}), because the cofactor clearing step will always
+map the point (v, w) = (0, -1) to the identity point.)
 
 Composing the mapping of this section with the mapping from
 Montgomery to Weierstrass curves in {{appx-rational-map-mont}}

--- a/poc/Makefile
+++ b/poc/Makefile
@@ -24,5 +24,10 @@ vectors: pyfiles
 	@mkdir -p vectors ascii
 	sage test_vectors.sage
 
+.PHONY: clean
 clean:
-	rm -rf sagelib *.pyc *.sage.py *.log vectors ascii
+	rm -rf sagelib *.pyc *.sage.py *.log
+
+.PHONY: distclean
+distclean: clean
+	rm -rf vectors ascii

--- a/poc/ell2edw_generic.sage
+++ b/poc/ell2edw_generic.sage
@@ -16,9 +16,12 @@ class GenericEll2Edw(GenericMap):
         d = F(d)
         self.a = a
         self.d = d
-        assert a != 0, "Edwards curve requires a != 0"
-        assert d != 0, "Edwards curve requires d != 0"
-        assert a != d, "Edwards curve requires a != d"
+        if a == 0:
+            raise ValueError("Edwards curve requires a != 0")
+        if d == 0:
+            raise ValueError("Edwards curve requires d != 0")
+        if a == d:
+            raise ValueError("Edwards curve requires a != d")
 
         # equivalent Montgomery curve
         self.A = (a + d) / F(2)

--- a/poc/ell2edw_generic.sage
+++ b/poc/ell2edw_generic.sage
@@ -24,80 +24,75 @@ class GenericEll2Edw(GenericMap):
             raise ValueError("Edwards curve requires a != d")
 
         # equivalent Montgomery curve
-        self.A = (a + d) / F(2)
-        self.B = (a - d)^2 / F(16)
-        self.Bp = F(4) / (a - d)
-        self.ell2_map = GenericEll2(F, self.A, self.B)
+        J = F(2) * (a + d) / (a - d)
+        K = F(4) / (a - d)
+        self.ell2_map = GenericEll2(F, J, K)
 
         # Montgomery points at which the rational map is undefined
         self.undefs = [(0, 0)]
-        xtest = -F(1) / self.Bp
-        y2test = xtest^3 + self.A * xtest^2 + self.B * xtest
-        if y2test.is_square():
-            ytest = y2test.sqrt()
-            self.undefs += [(xtest, ytest), (xtest, -ytest)]
+        stest = -F(1)
+        t2test = (stest^3 + J * stest^2 + stest) / K
+        if t2test.is_square():
+            ttest = t2test.sqrt()
+            self.undefs += [(stest, ttest), (stest, -ttest)]
 
     def not_straight_line(self, u):
-        (xp, yp) = self.ell2_map.not_straight_line(u)
-        return self.nsl_map(xp, yp)
+        (s, t) = self.ell2_map.not_straight_line(u)
+        return self.nsl_map(s, t)
 
-    def nsl_map(self, X, Y):
-        invSqrtD = self.Bp
-
-        xnum = X
-        xden = Y
-        ynum = invSqrtD * X - 1
-        yden = invSqrtD * X + 1
-        if xden * yden == 0:
+    def nsl_map(self, s, t):
+        vnum = s
+        vden = t
+        wnum = (s - 1)
+        wden = (s + 1)
+        if vden * wden == 0:
             return (0, 1)
-        return (xnum / xden, ynum / yden)
+        return (vnum / vden, wnum / wden)
 
-    def nsl_map_inv(self, v, w):
-        invSqrtD = self.Bp
-
-        xnum = ynum = 1 + w
-        xden = invSqrtD * (1 - w)
-        yden = xden * v
-        if xden * yden == 0:
-            return (0, 0)
-        return (xnum / xden, ynum / yden)
+    def to_weierstrass(self, v, w):
+        snum = tnum = 1 + w
+        sden = 1 - w
+        tden = sden * v
+        if sden * tden == 0:
+            (s, t) = (0, 0)
+        else:
+            (s, t) = (snum / sden, tnum / tden)
+        return self.ell2_map.to_weierstrass(s, t)
 
     def straight_line(self, u):
-        (xp, yp) = self.ell2_map.straight_line(u)
-        return self.sl_map(xp, yp)
+        (s, t) = self.ell2_map.straight_line(u)
+        return self.sl_map(s, t)
 
-    def sl_map(self, X, Y):
-        invSqrtD = self.Bp
+    def sl_map(self, s, t):
         inv0 = self.inv0
 
-        tv1 = X * invSqrtD
-        tv2 = tv1 + 1
-        tv3 = Y * tv2
-        tv3 = inv0(tv3)
-        v = tv2 * tv3
-        v = v * X
-        w = tv1 - 1
-        w = w * Y
-        w = w * tv3
-        e = w == 0
-        w = CMOV(w, 1, e)
+        tv1 = s + 1
+        tv2 = tv1 * t        # (s + 1) * t
+        tv2 = inv0(tv2)      # 1 / ((s + 1) * t)
+        v = tv2 * tv1      # 1 / t
+        v = v * s          # s / t
+        w = tv2 * t        # 1 / (s + 1)
+        tv1 = s - 1
+        w = w * tv1        # (s - 1) / (s + 1)
+        e = tv2 == 0
+        w = CMOV(w, 1, e)  # handle exceptional case
         return (v, w)
 
     def map_to_curve(self, u):
-        (x1, y1) = self.straight_line(u)
-        (x2, y2) = self.not_straight_line(u)
-        assert (x1, y1) == (x2, y2), "straight-line / non-straight-line mismatch"
-        assert self.a * x1^2 + y1^2 == 1 + self.d * x1^2 * y1^2
-        (x3, y3) = self.nsl_map_inv(x1, y1)
+        (v1, w1) = self.straight_line(u)
+        (v2, w2) = self.not_straight_line(u)
+        assert (v1, w1) == (v2, w2), "straight-line / non-straight-line mismatch"
+        assert self.a * v1^2 + w1^2 == 1 + self.d * v1^2 * w1^2
+        (x, y) = self.to_weierstrass(v1, w1)
         ret = self.ell2_map.map_to_curve(u)
-        assert (x3, y3) == (ret[0], ret[1])
+        assert (x, y) == (ret[0], ret[1])
         return ret
 
-    def test_map(self, xp, yp):
-        (x1, y1) = self.nsl_map(xp, yp)
-        (x2, y2) = self.sl_map(xp, yp)
-        assert (x1, y1) == (x2, y2)
-        assert self.a * x1^2 + y1^2 == 1 + self.d * x1^2 * y1^2
+    def test_map(self, s, t):
+        (v1, w1) = self.nsl_map(s, t)
+        (v2, w2) = self.sl_map(s, t)
+        assert (v1, w1) == (v2, w2)
+        assert self.a * v1^2 + w1^2 == 1 + self.d * v1^2 * w1^2
 
     def test_undef(self):
         for undef in self.undefs:

--- a/poc/generic_map.sage
+++ b/poc/generic_map.sage
@@ -32,7 +32,7 @@ class GenericMap(object):
         (x1, y1) = self.straight_line(u)
         (x2, y2) = self.not_straight_line(u)
         assert (x1, y1) == (x2, y2), "straight-line / non-straight-line mismatch"
-        return self.E(x1, y1)
+        return self.E(*self.to_weierstrass(x1, y1))
 
     def is_square(self, x):
         return self.F(x).is_square()
@@ -50,6 +50,9 @@ class GenericMap(object):
         self.test_undef()
         for _ in range(0, 256):
             self.map_to_curve(self.F.random_element())
+
+    def to_weierstrass(self, xin, yin):
+        return (xin, yin)
 
     @classmethod
     def get_random(cls):
@@ -69,8 +72,8 @@ class GenericMap(object):
                 # randomly pick sgn0_le or sgn0_be
                 if randint(0, 1) == 1:
                     ret.set_sgn0(sgn0_be)
-            except:
-                # constructor threw exception
+            except ValueError as e:
+                # constructor threw ValueError: this curve is not valid for this map
                 continue
             return ret
 

--- a/poc/h2c_suite.sage
+++ b/poc/h2c_suite.sage
@@ -150,16 +150,10 @@ class MontyH2CSuite(BasicH2CSuite):
         assert isinstance(sdef, BasicH2CSuiteDef)
 
         # figure out mapping to required Weierstrass form and init base class
-        F = sdef.F
-        Ap = F(sdef.Aa)
-        Bp = F(sdef.Bd)
-        A = Ap / Bp
-        B = 1 / Bp^2
-        self.Bp = Bp
-        super(MontyH2CSuite, self).__init__(name, sdef._replace(Aa=A, Bd=B, MapT=GenericEll2))
+        super(MontyH2CSuite, self).__init__(name, sdef._replace(MapT=GenericEll2))
 
         # helper: do point ops directly on the Monty repr
-        self.monty = MontgomeryCurve(F, Ap, Bp)
+        self.monty = MontgomeryCurve(sdef.F, sdef.Aa, sdef.Bd)
         self.to_self = self.monty.to_self
 
 class EdwH2CSuite(MontyH2CSuite):

--- a/poc/sswu_generic.sage
+++ b/poc/sswu_generic.sage
@@ -15,8 +15,10 @@ class GenericSSWU(GenericMap):
         self.F = F
         self.A = F(A)
         self.B = F(B)
-        assert self.A != 0, "S-SWU requires A != 0"
-        assert self.B != 0, "S-SWU requires B != 0"
+        if self.A == 0:
+            raise ValueError("S-SWU requires A != 0")
+        if self.B == 0:
+            raise ValueError("S-SWU requires B != 0")
         self.Z = find_z_sswu(F, F(A), F(B))
         self.E = EllipticCurve(F, [F(A), F(B)])
 


### PR DESCRIPTION
This PR addresses the issues discussed in #195 by making the "long Weierstrass" transformations part of the Elligator2 map. The hope is that this makes the Elligator2 section clearer.

It also updates the code in `poc/` to match the descriptions in the text.

Closes #195