### PR TITLE
Pointing to named versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The purpose of these implementations is for generating test vectors and enabling
 These implementations are for reference only. They MUST NOT be used in production systems.
 
  - [Sage](https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve/tree/master/poc)
- - [Go](https://github.com/armfazh/h2c-go-ref)
+ - [Go](https://github.com/armfazh/h2c-go-ref): [v06](https://github.com/armfazh/h2c-go-ref/tree/v6.0.0), [v05](https://github.com/armfazh/h2c-go-ref/tree/v5.0.0)
 
 ## Contributing
 


### PR DESCRIPTION
Go reference implementation supports v06 using a tagged commit.