### PR TITLE
Pointers to rust reference implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These implementations are for reference only. They MUST NOT be used in productio
 
  - [Sage](https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve/tree/master/poc)
  - [Go](https://github.com/armfazh/h2c-go-ref): [v06](https://github.com/armfazh/h2c-go-ref/tree/v6.0.0), [v05](https://github.com/armfazh/h2c-go-ref/tree/v5.0.0)
+ - [Rust](https://github.com/armfazh/h2c-rust-ref): [v06](https://github.com/armfazh/h2c-rust-ref/tree/v6.0.0), [v05](https://github.com/armfazh/h2c-rust-ref/tree/v5.0.0)
 
 ## Contributing
 


### PR DESCRIPTION
I've created a rust reference implementation compatible with v05 and v06