### PR TITLE
clarifications based on feedback from VRF authors

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1851,14 +1851,14 @@ Constants:
 
 - A and B, the parameter of the Weierstrass curve.
 
-- Z, an element of F meeting the below criteria.
+- Z, a non-zero element of F meeting the below criteria.
   {{svdw-z-code}} gives a Sage {{SAGE}} script that outputs the RECOMMENDED Z.
   1. g(Z) != 0 in F.
   2. -(3 * Z^2 + 4 * A) / (4 * g(Z)) != 0 in F.
   3. -(3 * Z^2 + 4 * A) / (4 * g(Z)) is square in F.
   4. At least one of g(Z) and g(-Z / 2) is square in F.
 
-Sign of y: Inputs u and -u give the same x-coordinate.
+Sign of y: Inputs u and -u give the same x-coordinate for many values of u.
 Thus, we set sgn0(y) == sgn0(u).
 
 Exceptions: The exceptional cases for u occur when

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2405,14 +2405,16 @@ the subsection that gives the corresponding parameters.
 A hash-to-curve suite requires the following functions.
 Note that some of these require utility functions from {{utility}}.
 
-1. Target elliptic curve operations, e.g., point addition and scalar multiplication.
+1. Base field arithmetic operations for the target elliptic curve, e.g.,
+   addition, multiplication, and square root.
 
-2. Target elliptic curve base field operations, e.g., addition, multiplication, and square root.
+2. Elliptic curve point operations for the target curve, e.g.,
+   point addition and scalar multiplication.
 
 3. The hash-to-field function; see {{hashtofield}}. This includes the expand\_message
    variant ({{hashtofield-expand}}) and any constituent hash function or XOF.
 
-4. The suite-specific mapping function; see {{mappings}}.
+4. The suite-specified mapping function; see the corresponding subsection of {{mappings}}.
 
 5. A cofactor clearing function; see {{cofactor-clearing}}. This may be implemented as 
    scalar multiplication by h\_eff or as a faster equivalent method.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1173,8 +1173,8 @@ This section presents a general framework for encoding byte strings to points
 on an elliptic curve. To construct these encodings, we rely on three basic
 functions:
 
--   The function hash\_to\_field, {0, 1}^\* x {1, 2, ...} -> F, hashes arbitrary-length byte strings
-    to elements of a finite field; its implementation is defined in
+-   The function hash\_to\_field, {0, 1}^\* x {1, 2, ...} -> (F, F, ...), hashes arbitrary-length byte strings
+    to a list of one or more elements of a finite field; its implementation is defined in
     {{hashtofield}}.
 
 -   The function map\_to\_curve, F -> E, calculates a point on the elliptic curve E
@@ -2405,20 +2405,20 @@ the subsection that gives the corresponding parameters.
 A hash-to-curve suite requires the following functions.
 Note that some of these require utility functions from {{utility}}.
 
-1. Working operations on the target elliptic curve (e.g., point addition,
-   scalar multiplication) and in the curve's base field (e.g., addition,
-   multiplication, square root).
+1. Target elliptic curve operations, e.g., point addition and scalar multiplication.
 
-2. The hash-to-field function ({{hashtofield}}), including the expand\_message
+2. Target elliptic curve base field operations, e.g., addition, multiplication, and square root.
+
+3. The hash-to-field function; see {{hashtofield}}. This includes the expand\_message
    variant ({{hashtofield-expand}}) and any constituent hash function or XOF.
 
-3. The mapping function specified by the suite; see {{mappings}}.
+4. The suite-specific mapping function; see {{mappings}}.
 
-4. A cofactor clearing function, which may be implemented as scalar multiplication
-   by h\_eff or as a faster equivalent method; see {{cofactor-clearing}}.
+5. A cofactor clearing function; see {{cofactor-clearing}}. This may be implemented as 
+   scalar multiplication by h\_eff or as a faster equivalent method.
 
-5. The encoding function, either hash\_to\_curve or encode\_to\_curve; see
-   {{roadmap}}.
+6. The desired encoding function; see {{roadmap}}. This is either hash\_to\_curve or 
+   encode\_to\_curve.
 
 ## Suites for NIST P-256 {#suites-p256}
 


### PR DESCRIPTION
This PR adds small clarifications:

- makes a new subsection in Suites that gives a step-by-step guide

- forward refs here from the intro rather than repeating that info there

- changes the section name "Roadmap" to "Encoding byte strings to elliptic curves". Got feedback from several people that "Roadmap" wasn't sufficiently evocative and/or didn't actually describe the content of the section.

- tweak to the way Z is specified and the justification for choice of sgn0(y) for SvdW

The VRF authors specifically requested changes along the lines of the first three to make it easier for users of their document once they incorporate us by ref. This doesn't mean we must do exactly what I've done in this PR, of course.

I'm hopeful that VRF will accept our PR once we get something like these clarifications in place!