### PR TITLE
Domain separation discussion in Security Considerations

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2734,13 +2734,13 @@ If further separation is required among uses of H outside of
 hash\_to\_field, protocols should choose multiple tags that are
 all distinct from one another and from DST\_prime.
 
-The above method is not compatible with all uses of H;
+The above method is not compatible with all uses of H.
 For example, this method does not work with HMAC {{RFC2104}},
-because there is no way to append a value to the outer call to
-the hash function.
-(We discuss the case of HMAC further below.)
+because there is no way to append a value to the input of
+the outer call to H.
 The following alternative methods MAY be used instead of the
 recommended method given above.
+We discuss the specific case of HMAC further below.
 
 1. For each use of H outside hash\_to\_field, choose a unique domain
    separation tag DST\_ext. Augment each invocation of H on input msg by

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2753,8 +2753,8 @@ either of the following two methods MAY be used instead.
    For example, for two invocations of H whose inputs are msg1 and msg2,
    one might choose distinct DST\_ext1 and DST\_ext2 and compute
 
-        hash1 = H(DST\_ext1 || msg1 || I2OSP(0, 1))
-        hash2 = H(DST\_ext2 || msg2 || I2OSP(0, 1))
+        hash1 = H(DST_ext1 || msg1 || I2OSP(0, 1))
+        hash2 = H(DST_ext2 || msg2 || I2OSP(0, 1))
 
 2. For each invocation of H outside expand\_message\_xmd, choose a unique domain
    separation tag DST\_ext.
@@ -2776,8 +2776,8 @@ either of the following two methods MAY be used instead.
    one might choose distinct nonzero DST\_ext1 and DST\_ext2 of length
    b bits each and compute
 
-        hash1 = H(DST\_ext1 || msg1)
-        hash2 = H(DST\_ext2 || msg2)
+        hash1 = H(DST_ext1 || msg1)
+        hash2 = H(DST_ext2 || msg2)
 
 Other expand\_message variants that follow the guidelines in
 {{hashtofield-expand-other}} are expected to have similar properties,

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1251,16 +1251,19 @@ The following requirements apply:
 1. Tags MUST be supplied as the DST parameter to hash\_to\_field, as
    described in {{hashtofield}}.
 
-2. Tags MUST begin with a fixed protocol identification string.
-   This identification string should be unique to the protocol.
+2. Tags MUST have nonzero length. A minimum length of 8 bytes
+   is RECOMMENDED.
 
-3. Tags SHOULD include a protocol version number.
+3. Tags SHOULD begin with a fixed protocol identification string
+   that is unique to the protocol.
 
-4. For protocols that define multiple ciphersuites, each ciphersuite's
+4. Tags SHOULD include a protocol version number.
+
+5. For protocols that define multiple ciphersuites, each ciphersuite's
    tag MUST be different. For this purpose, it is RECOMMENDED to
    include a ciphersuite identifier in each tag.
 
-5. For protocols that use multiple encodings, either to the same curve
+6. For protocols that use multiple encodings, either to the same curve
    or to different curves, each encoding MUST use a different tag.
    For this purpose, it is RECOMMENDED to include the encoding's
    Suite ID ({{suites}}) in the domain separation tag.
@@ -1269,15 +1272,17 @@ The following requirements apply:
 
 As an example, consider a fictional protocol named Quux
 that defines several different ciphersuites.
-A reasonable choice of tag is "QUUX-V\<xx\>-CS\<yy\>", where \<xx\> and \<yy\>
-are two-digit numbers indicating the version and ciphersuite, respectively.
+A reasonable choice of tag is "QUUX-V\<xx\>-CS\<yy\>-\<suiteID\>", where
+\<xx\> and \<yy\> are two-digit numbers indicating the version and
+ciphersuite, respectively, and \<suiteID\> is the Suite ID of the
+encoding used in ciphersuite \<yy\>.
 
 As another example, consider a fictional protocol named Baz that requires
 two independent random oracles, where one oracle outputs points on the curve
 E1 and the other outputs points on the curve E2.
 Reasonable choices of tags for the E1 and E2 oracles are
-"BAZ-V\<xx\>-CS\<yy\>-E1" and "BAZ-V\<xx\>-CS\<yy\>-E2", respectively,
-where \<xx\> and \<yy\> are as described above.
+"BAZ-V\<xx\>-CS\<yy\>-\<suiteID\>-E1" and "BAZ-V\<xx\>-CS\<yy\>-\<suiteID\>-E2",
+respectively, where \<xx\>, \<yy\>, and \<suiteID\> are as described above.
 
 # Utility functions {#utility}
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2732,8 +2732,9 @@ ciphersuites with higher security levels.
 The authors would like to thank Adam Langley for his detailed writeup of Elligator 2 with
 Curve25519 {{L13}};
 Dan Boneh, Christopher Patton, and Benjamin Lipp for educational discussions; and
-David Benjamin, Frank Denis, Sean Devlin, Justin Drake, Dan Harkins, Thomas Icart,
-Andy Polyakov, Leonid Reyzin, Michael Scott, and Mathy Vanhoef for helpful feedback.
+David Benjamin, Frank Denis, Sean Devlin, Justin Drake, Bjoern Haase, Mike Hamburg,
+Dan Harkins, Thomas Icart, Andy Polyakov, Mamy Ratsimbazafy, Leonid Reyzin, Michael Scott,
+and Mathy Vanhoef for helpful feedback.
 
 # Contributors
 

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2728,7 +2728,7 @@ The RECOMMENDED method of ensuring domain separation is appending a tag
 distinct from DST\_prime to all inputs to H outside of hash\_to\_field.
 This ensures that distinct invocations of H have distinct suffixes.
 If further separation is required among invocations of H outside of
-hash\_to\_field, protocols should define multiple tags that are
+hash\_to\_field, protocols should use multiple tags that are
 all distinct from one another and from DST\_prime.
 
 For protocols that use expand\_message\_xmd ({{hashtofield-expand-xmd}}),
@@ -2767,7 +2767,7 @@ used with expand\_message\_xof.
    Since DST\_ext contains at least one nonzero bit among its first b bits,
    it is guaranteed to be distinct from the value Z\_pad
    ({{hashtofield-expand-xmd}}, step 4), which ensures that all inputs to H
-   are distinct from the input used to generate b\_0.
+   are distinct from the input used to generate b\_0 in expand\_message\_xmd.
    Moreover, since DST\_ext is at least b bits long, it is almost certainly
    distinct from the values b\_0 and strxor(b\_0, b\_(i - 1)), and therefore
    all inputs to H are distinct from the inputs used to generate b\_i, i >= 1,
@@ -2787,19 +2787,22 @@ but these should be analyzed on a case-by-case basis.
 In addition to the above considerations, protocols that use Merkle-Damgaard
 hash functions as random oracles should be extremely careful to defend
 against length extension and other well known attacks.
-expand\_message\_xmd is designed to guard against these attacks, and
+expand\_message\_xmd is designed to guard against these attacks.
+It can be used as a random oracle outside of hash\_to\_field, and
 can be domain separated from invocations inside hash\_to\_field simply
 by choosing a different DST.
 
 Another possibility is to use HMAC {{RFC2104}}.
 HMAC can be domain separated from expand\_message\_xmd using method 2
-by deriving a HMAC key from DST\_ext as follows:
+(above) by deriving a HMAC key from DST\_ext and applying HMAC to
+the random oracle's input as follows:
 
     DST_ext_prime = HMAC(0, "HMAC-DERIVE-DST-" || DST_ext)
-    hash = HMAC(DST_ext_prime, msg)
+    random_oracle_output = HMAC(DST_ext_prime, random_oracle_input)
 
 This works because with overwhelming probability the inputs to H inside
-of HMAC do not equal Z\_pad, b\_0, or strxor(b\_0, b\_(i - 1)).
+of HMAC with key DST\_ext\_prime do not equal Z\_pad, b\_0, or
+strxor(b\_0, b\_(i - 1)).
 
 {{CDMP05}} studies issues with using Merkle-Damgaard hash functions as
 random oracles in detail.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2737,20 +2737,19 @@ The first method MAY also be used with expand\_message\_xof
 ({{hashtofield-expand-xof}}), but the second method MUST NOT be
 used with expand\_message\_xof.
 
-1. For each invocation of H outside hash\_to\_field, choose a unique domain
-   separation tag DST\_ext.
-   Prepend DST\_ext to the input to H, and in addition append a single
-   zero byte to this input.
+1. For each use of H outside hash\_to\_field, choose a unique domain
+   separation tag DST\_ext. Augment each invocation of H with input msg by
+   computing H(DST\_ext || msg || I2OSP(0, 1)).
 
    Appending the byte I2OSP(0, 1) to all inputs to H outside hash\_to\_field
    ensures that these inputs are distinct from those inside hash\_to\_field
    because the final byte of DST\_prime encodes the length of DST, which is
-   required to be nonzero ({{domain-separation}}), and DST\_prime is always
+   required to be nonzero ({{domain-separation}}, requirement 2), and DST\_prime is always
    appended to invocations of H inside hash\_to\_field.
    Further, distinct DST\_ext values ensure that invocations of H outside
    hash\_to\_field are distinct from one another.
 
-   For example, for two invocations of H whose inputs are msg1 and msg2,
+   For example, for two uses of H whose inputs are msg1 and msg2,
    one might choose distinct DST\_ext1 and DST\_ext2 and compute
 
         hash1 = H(DST_ext1 || msg1 || I2OSP(0, 1))
@@ -2773,7 +2772,7 @@ used with expand\_message\_xof.
    all inputs to H are distinct from the inputs used to generate b\_i, i >= 1,
    with high probability.
 
-   For example, for two invocations of H whose inputs are msg1 and msg2,
+   For example, for two uses of H whose inputs are msg1 and msg2,
    one might choose distinct nonzero DST\_ext1 and DST\_ext2 of length
    b bits each and compute
 
@@ -2781,15 +2780,15 @@ used with expand\_message\_xof.
         hash2 = H(DST_ext2 || msg2)
 
 Other expand\_message variants that follow the guidelines in
-{{hashtofield-expand-other}} are expected to have similar properties,
-but these should be analyzed on a case-by-case basis.
+{{hashtofield-expand-other}} are expected to have similar properties.
+However, these should be analyzed on a case-by-case basis.
 
 In addition to the above considerations, protocols that use Merkle-Damgaard
 hash functions as random oracles should be extremely careful to defend
 against length extension and other well known attacks.
-expand\_message\_xmd is designed to guard against these attacks.
-It can be used as a random oracle outside of hash\_to\_field, and
-can be domain separated from invocations inside hash\_to\_field simply
+expand\_message\_xmd guards against these attacks.
+Applications can use it as a random oracle outside of hash\_to\_field
+with proper domain separation from invocations inside hash\_to\_field
 by choosing a different DST.
 
 Another possibility is to use HMAC {{RFC2104}}.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2733,21 +2733,22 @@ all distinct from one another and from DST\_prime.
 
 For protocols that use expand\_message\_xmd ({{hashtofield-expand-xmd}}),
 either of the following two methods MAY be used instead.
-(Note that these methods MUST NOT be used with expand\_message\_xof
-({{hashtofield-expand-xof}}).)
+The first method MAY also be used with expand\_message\_xof
+({{hashtofield-expand-xof}}), but the second method MUST NOT be
+used with expand\_message\_xof.
 
-1. For each invocation of H outside expand\_message\_xmd, choose a unique domain
+1. For each invocation of H outside hash\_to\_field, choose a unique domain
    separation tag DST\_ext.
    Prepend DST\_ext to the input to H, and in addition append a single
    zero byte to this input.
 
-   Appending the byte I2OSP(0, 1) to all inputs to H outside expand\_message\_xmd
-   ensures that these inputs are distinct from those inside expand\_message\_xmd
+   Appending the byte I2OSP(0, 1) to all inputs to H outside hash\_to\_field
+   ensures that these inputs are distinct from those inside hash\_to\_field
    because the final byte of DST\_prime encodes the length of DST, which is
    required to be nonzero ({{domain-separation}}), and DST\_prime is always
-   appended to invocations of H inside expand\_message\_xmd.
+   appended to invocations of H inside hash\_to\_field.
    Further, distinct DST\_ext values ensure that invocations of H outside
-   expand\_message\_xmd are distinct from one another.
+   hash\_to\_field are distinct from one another.
 
    For example, for two invocations of H whose inputs are msg1 and msg2,
    one might choose distinct DST\_ext1 and DST\_ext2 and compute
@@ -2755,7 +2756,8 @@ either of the following two methods MAY be used instead.
         hash1 = H(DST_ext1 || msg1 || I2OSP(0, 1))
         hash2 = H(DST_ext2 || msg2 || I2OSP(0, 1))
 
-2. For each invocation of H outside expand\_message\_xmd, choose a unique domain
+2. (Note: this method MUST NOT be used with expand\_message\_xof.)
+   For each invocation of H outside expand\_message\_xmd, choose a unique domain
    separation tag DST\_ext.
    DST\_ext MUST be at least b bits long, where b is the number of bits output
    by the hash function H, and it MUST contain at least one nonzero bit among

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2720,14 +2720,13 @@ affect the distribution of the b\_i values.
 The expand\_message variants in this document ({{hashtofield-expand}})
 always append a suffix-free-encoded domain separation tag DST\_prime
 to the strings hashed by H, the underlying hash or extensible output function.
-
 For protocols that also invoke H outside of hash\_to\_field, those invocations
 MUST be domain separated from all uses of H inside hash\_to\_field, and SHOULD
 be domain separated from uses of H outside of the protocol.
 
 The RECOMMENDED method of ensuring domain separation is appending a tag
-distinct from DST\_prime to all inputs to H outside of hash\_to\_field;
-this ensures that distinct invocations of H have distinct suffixes.
+distinct from DST\_prime to all inputs to H outside of hash\_to\_field.
+This ensures that distinct invocations of H have distinct suffixes.
 If further separation is required among invocations of H outside of
 hash\_to\_field, protocols should define multiple tags that are
 all distinct from one another and from DST\_prime.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2801,15 +2801,20 @@ based on a Merkle-Damgaard hash function.
 To domain separate expand\_message\_xmd instantiated with hash H
 from HMAC instantiated with H, it suffices to choose an HMAC key
 whose preimage under H is distinct from all possible inputs to
-expand\_message\_xmd.
+H inside expand\_message\_xmd.
 For example, one can choose a distinct tag DST\_ext and compute
 
-    DST_ext_prime = HMAC(0, "HMAC-DERIVE-DST-" || DST_ext)
+    DST_ext_prime = H("DERIVE-HMAC-KEY-" || DST_ext || I2OSP(0, 1))
     random_oracle_output = HMAC(DST_ext_prime, random_oracle_input)
 
-This ensures domain separation because with overwhelming probability
-the inputs to H inside of HMAC with key DST\_ext\_prime do not equal
-Z\_pad, b\_0, or strxor(b\_0, b\_(i - 1)).
+The trailing zero byte in the input to H ensures that DST\_ext\_prime's
+preimage under H is distinct from any input to H inside expand\_message\_xmd:
+all inputs to H inside expand\_message\_xmd have suffix DST\_prime,
+which cannot end with a zero byte as discussed above.
+Using DST\_ext\_prime as an HMAC key ensures domain separation from
+expand\_message\_xmd because with overwhelming probability the inputs
+to H inside of HMAC with key DST\_ext\_prime do not begin with Z\_pad,
+b\_0, or strxor(b\_0, b\_(i - 1)).
 
 {{CDMP05}} studies issues with using Merkle-Damgaard hash functions as
 random oracles.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2798,23 +2798,21 @@ with proper domain separation from invocations inside hash\_to\_field
 
 HMAC {{RFC2104}} is commonly used to instantiate a random oracle
 based on a Merkle-Damgaard hash function.
-To domain separate expand\_message\_xmd instantiated with hash H
-from HMAC instantiated with H, it suffices to choose an HMAC key
-whose preimage under H is distinct from all possible inputs to
-H inside expand\_message\_xmd.
-For example, one can choose a distinct tag DST\_ext and compute
+The RECOMMENDED way to domain separate HMAC-H (i.e., HMAC instantiated
+with hash H) from expand\_message\_xmd instantiated with H is to
+first choose a tag DST\_ext, then compute
 
-    DST_ext_prime = H("DERIVE-HMAC-KEY-" || DST_ext || I2OSP(0, 1))
-    random_oracle_output = HMAC(DST_ext_prime, random_oracle_input)
+    HMAC_key_preimage = "DERIVE-HMAC-KEY-" || DST_ext || I2OSP(0, 1)
+    HMAC_key = H(HMAC_key_preimage)
 
-The trailing zero byte in the input to H ensures that DST\_ext\_prime's
-preimage under H is distinct from any input to H inside expand\_message\_xmd:
-all inputs to H inside expand\_message\_xmd have suffix DST\_prime,
-which cannot end with a zero byte as discussed above.
-Using DST\_ext\_prime as an HMAC key ensures domain separation from
-expand\_message\_xmd because with overwhelming probability the inputs
-to H inside of HMAC with key DST\_ext\_prime do not begin with Z\_pad,
-b\_0, or strxor(b\_0, b\_(i - 1)).
+The trailing zero byte in HMAC\_key\_preimage ensures that this value
+is distinct from inputs to H inside expand\_message\_xmd (because all
+such inputs have suffix DST\_prime, which cannot end with a zero byte
+as discussed above).
+This ensures domain separation because, with overwhelming probability, all
+inputs to H inside of HMAC using key HMAC\_key have prefixes that are distinct
+from the values Z\_pad, b\_0, and strxor(b\_0, b\_(i - 1)) inside of
+expand\_message\_xmd.
 
 {{CDMP05}} studies issues with using Merkle-Damgaard hash functions as
 random oracles.

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -64,6 +64,7 @@ normative:
         ins: A. Langley
         name: Adam Langley
 informative:
+  RFC2104:
   BLS12-381:
     target: https://electriccoin.co/blog/new-snark-curve/
     title: "BLS12-381: New zk-SNARK Elliptic Curve Construction"

--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -1252,8 +1252,9 @@ The following requirements apply:
 1. Tags MUST be supplied as the DST parameter to hash\_to\_field, as
    described in {{hashtofield}}.
 
-2. Tags MUST have nonzero length. A minimum length of 8 bytes
-   is RECOMMENDED.
+2. Tags MUST have nonzero length. A minimum length of 16 bytes
+   is RECOMMENDED to reduce the chance of collisions with other
+   protocols.
 
 3. Tags SHOULD begin with a fixed protocol identification string
    that is unique to the protocol.


### PR DESCRIPTION
This PR:

- updates acknowledgments
- slightly tweaks and clarifies the domain separation requirements
- adds a discussion of "external" domain separation in the Security Recommendations section

closes #256