### PR TITLE
Export curve paramters (for code reuse).

### DIFF
--- a/poc/suite_25519.sage
+++ b/poc/suite_25519.sage
@@ -75,6 +75,16 @@ assert edw25519_sha512_ro.m2c.Z == edw25519_sha512_nu.m2c.Z == 2
 assert monty25519_sha512_ro.m2c.Z == monty25519_sha512_nu.m2c.Z == 2
 
 group_order = 2^252 + 0x14def9dea2f79cd65812631a5cf5d3ed
+curve25519_order = group_order
+curve25519_p = p
+curve25519_F = F
+curve25519_A = Ap
+curve25519_B = Bp
+edwards25519_order = group_order
+edwards25519_p = p
+edwards25519_F = F
+edwards25519_A = a
+edwards25519_B = a
 
 def _test_suite(edw_hash, monty_hash, m2e, grp_ord, nreps=128, is_equal=False):
     accumE = edw_hash('asdf')

--- a/poc/suite_448.sage
+++ b/poc/suite_448.sage
@@ -58,6 +58,16 @@ assert edw448_hash_ro.m2c.Z == edw448_hash_nu.m2c.Z == -1
 assert monty448_hash_ro.m2c.Z == monty448_hash_nu.m2c.Z == -1
 
 group_order = 2^446 - 0x8335dc163bb124b65129c96fde933d8d723a70aadc873d6d54a7bb0d
+curve448_order = group_order
+curve448_p = p
+curve448_F = F
+curve448_A = Ap
+curve448_B = Bp
+edwards449_order = group_order
+edwards449_p = p
+edwards449_F = F
+edwards449_A = a
+edwards449_B = a
 
 def test_suite_448():
     _test_suite(edw448_hash_ro, monty448_hash_ro, m2e_448, group_order)

--- a/poc/suite_p256.sage
+++ b/poc/suite_p256.sage
@@ -39,6 +39,10 @@ assert p256_sswu_ro.m2c.Z == p256_sswu_nu.m2c.Z == -10
 assert p256_svdw_ro.m2c.Z == p256_svdw_nu.m2c.Z ==  -3
 
 p256_order = 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551
+p256_p = p
+p256_F = F
+p256_A = A
+p256_B = B
 
 def _test_suite(suite, group_order, nreps=128):
     accum = suite('asdf')

--- a/poc/suite_p384.sage
+++ b/poc/suite_p384.sage
@@ -40,6 +40,10 @@ assert p384_sswu_ro.m2c.Z == p384_sswu_nu.m2c.Z == -12
 assert p384_svdw_ro.m2c.Z == p384_svdw_nu.m2c.Z == -1
 
 p384_order = 0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973
+p384_p = p
+p384_F = F
+p384_A = A
+p384_B = B
 
 def test_suite_p384():
     _test_suite(p384_sswu_ro, p384_order)

--- a/poc/suite_p521.sage
+++ b/poc/suite_p521.sage
@@ -40,6 +40,10 @@ assert p521_sswu_ro.m2c.Z == p521_sswu_nu.m2c.Z == -4
 assert p521_svdw_ro.m2c.Z == p521_svdw_nu.m2c.Z == 1
 
 p521_order = 0x1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409
+p521_p = p
+p521_F = F
+p521_A = A
+p521_B = B
 
 def test_suite_p521():
     _test_suite(p521_sswu_ro, p521_order)

--- a/poc/suite_secp256k1.sage
+++ b/poc/suite_secp256k1.sage
@@ -45,6 +45,10 @@ assert secp256k1_sswu_ro.m2c.Z == secp256k1_sswu_nu.m2c.Z == -11
 assert secp256k1_svdw_ro.m2c.Z == secp256k1_svdw_nu.m2c.Z == 1
 
 secp256k1_order = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+secp256k1_p = p
+secp256k1_F = F
+secp256k1_A = A
+secp256k1_B = B
 
 def test_suite_secp256k1():
     _test_suite(secp256k1_sswu_ro, secp256k1_order)


### PR DESCRIPTION
This makes it easier to use this code as a submodule without for other reference implementations (VOPRF).