### PR TITLE
Address Thomas' nits.

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -7336,7 +7336,7 @@ uniform_bytes = 01524feea5b22f6509f6b1e805c97df94faf4d821b01aade
 
 name    = expand_message_xof
 DST     = QUUX-V01-CS02-with-expander
-hash    = SHAKE_128
+hash    = SHAKE128
 
 msg     =
 len_in_bytes = 0x20

--- a/poc/hash_to_field.py
+++ b/poc/hash_to_field.py
@@ -142,7 +142,11 @@ class Expander(object):
         raise Exception("Not implemented")
 
     def hash_name(self):
-        return self.hash_fn().name.upper()
+        name = self.hash_fn().name.upper()
+        # Python incorrectly says SHAKE_128 rather than SHAKE128
+        if name[:6] == "SHAKE_":
+            name = "SHAKE" + name[6:]
+        return name
 
     def __dict__(self):
         return {

--- a/poc/suite_bls12381g2.sage
+++ b/poc/suite_bls12381g2.sage
@@ -45,7 +45,7 @@ suite_name = "BLS12381G2_XMD:SHA-256_SSWU_NU_"
 bls12381g2_sswu_nu = IsoH2CSuite(suite_name,bls12381g2_sswu(suite_name, False))
 
 assert bls12381g2_sswu_ro.m2c.Z == bls12381g2_sswu_nu.m2c.Z == F(-2 - II)
-assert bls12381g2_svdw_ro.m2c.Z == bls12381g2_svdw_nu.m2c.Z == F(II)
+assert bls12381g2_svdw_ro.m2c.Z == bls12381g2_svdw_nu.m2c.Z == F(-1)
 
 bls12381g2_order = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
 

--- a/poc/test_vectors_appx.py
+++ b/poc/test_vectors_appx.py
@@ -68,7 +68,7 @@ for curve in (P256, P384, P521, curve25519, edwards25519, curve448, edwards448, 
 
 expand_message_xmd_sha256 = ("expand_message_xmd(SHA-256)", "expand_message_xmd_SHA256")
 expand_message_xmd_sha512 = ("expand_message_xmd(SHA-512)", "expand_message_xmd_SHA512")
-expand_message_xof_shake128 = ("expand_message_xof(SHAKE128)", "expand_message_xof_SHAKE_128")
+expand_message_xof_shake128 = ("expand_message_xof(SHAKE128)", "expand_message_xof_SHAKE128")
 
 # section header
 print("""

--- a/poc/vectors/expand_message_xof_SHAKE128.json
+++ b/poc/vectors/expand_message_xof_SHAKE128.json
@@ -1,6 +1,6 @@
 {
   "DST": "QUUX-V01-CS02-with-expander",
-  "hash": "SHAKE_128",
+  "hash": "SHAKE128",
   "name": "expand_message_xof",
   "tests": [
     {


### PR DESCRIPTION
Closes #292.

I think we should leave indentation nonsense to the RFC editor. We didn't change any of the pseudocode blocks, so it seems to be a tooling issue that (in my opinion) is not worth our time debugging.