### PR TITLE
Add Zig's standard library to the list of implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This is a (likely incomplete) list of other libraries that have implemented hash
  - [pairing-plus](https://github.com/algorand/pairing-plus)
  - [RELIC](https://github.com/relic-toolkit/relic)
  - [Apache Milagro Crypto Library - Rust](https://github.com/apache/incubator-milagro-crypto-rust)
+ - [Zig's standard library](https://ziglang.org)
 
 If you know of another library that supports a compliant hash-to-curve implementation and would like us to list it here, please open a PR.
 


### PR DESCRIPTION
The Zig programming language includes hash-to-curve support in its standard library.