### PR TITLE
Moves the template repo to main branch.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ ifneq (,$(shell grep "path *= *$(LIBDIR)" .gitmodules 2>/dev/null))
 	git submodule update $(CLONE_ARGS) --init
 else
 	git clone -q --depth 10 $(CLONE_ARGS) \
-	    -b master https://github.com/martinthomson/i-d-template $(LIBDIR)
+	    -b main https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif


### PR DESCRIPTION
This removes the warning message
```
lib/id.mk:10: **************************************************************
lib/id.mk:11: ***                                                        ***
lib/id.mk:12: ***   You are on the 'master' branch of i-d-template.      ***
lib/id.mk:13: ***   This branch is not supported.                        ***
lib/id.mk:14: ***   Please update to use 'main'.                         ***
lib/id.mk:15: ***                                                        ***
lib/id.mk:20: ***   sed -i~ s/master/main/ Makefile                      ***
lib/id.mk:21: ***   rm -rf lib                                           ***
lib/id.mk:23: ***                                                        ***
lib/id.mk:24: **************************************************************
```