### PR TITLE
Removes a reference to pairing-friendly expired draft

### DIFF
--- a/draft-irtf-cfrg-hash-to-curve.md
+++ b/draft-irtf-cfrg-hash-to-curve.md
@@ -2717,8 +2717,6 @@ to the curve E' isogenous to secp256k1 is given in {{straightline-sswu}}.
 
 This section defines ciphersuites for groups G1 and G2 of
 the BLS12-381 elliptic curve {{BLS12-381}}.
-The curve parameters in this section match the ones listed in
-{{!I-D.irtf-cfrg-pairing-friendly-curves}}, Appendix C.
 
 ### BLS12-381 G1 {#suites-bls12381-g1}
 


### PR DESCRIPTION
Suggestion raised by Watson Ladd (@wbl) posted at 
https://mailarchive.ietf.org/arch/msg/cfrg/LYZ09KNhZj6cRQ26Yc0IYHEuOYg/